### PR TITLE
2.0.0: New package name: `g`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ $ vcspull "$HOME/code/*"
 
 <img src="https://raw.githubusercontent.com/vcs-python/vcspull/master/docs/_static/vcspull-demo.gif" class="align-center" style="width:45.0%" alt="image" />
 
+# Credits
+
+2021-12-05: Thanks to [John Shanahan](https://github.com/shanahanjrs) ([@_shanahanjrs](https://twitter.com/_shanahanjrs)) for giving vcspull use [g](https://pypi.org/project/g/)
+
 # Donations
 
 Your donations fund development of new features, testing and support.

--- a/g.py
+++ b/g.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import pathlib
+import subprocess
+import sys
+
+vcspath_registry = {".git": "git", ".svn": "svn", ".hg": "hg"}
+
+
+def find_repo_type(path):
+    for path in list(pathlib.Path(path).parents) + [pathlib.Path(path)]:
+        for p in path.iterdir():
+            if p.is_dir():
+                if p.name in vcspath_registry:
+                    return vcspath_registry[p.name]
+
+
+vcs_bin = find_repo_type(pathlib.Path.cwd())
+
+
+def run(cmd=vcs_bin, cmd_args=sys.argv[1:], *args, **kwargs):
+    proc = subprocess.Popen([cmd, *cmd_args])
+    proc.communicate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,11 @@ classifiers = [
   "Topic :: System :: Shells"
 ]
 packages = [
-    { include = "vcspull" }
+    { include = "vcspull" },
 ]
 include = [
-    { path = "tests", format = "sdist" }
+    { path = "tests", format = "sdist" },
+    { path = "g.py" }
 ]
 readme = 'README.md'
 keywords = ["vcspull", "git", "vcs", "json", "yaml"]
@@ -39,6 +40,7 @@ Changes = "https://github.com/vcs-python/vcspull/blob/master/CHANGES"
 
 [tool.poetry.scripts]
 vcspull = 'vcspull:cli.cli'
+g = 'g:run'
 
 [tool.poetry.dependencies]
 python = "^3.7"
@@ -82,5 +84,5 @@ format = ["black", "isort"]
 lint = ["flake8"]
 
 [build-system]
-requires = ["poetry_core>=1.0.0"]
+requires = ["poetry_core>=1.0.0", "setuptools>60"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Credit to @shanahanjrs for providing access to [`g`](https://pypi.org/project/g/) on pypi

### Changes:

- Default command: `g` / `vcspull` no longer updates all repos, instead shows subcommands

### Upcoming milestones:

- Scan for repos #25

  Scan for repos and add them to yaml file

- Update repos by directory

  e.g. `g up ~/work/*/python`, `g update ~/work/*/python`
 
 - Blocker: https://github.com/ohmyzsh/ohmyzsh/blob/58478d0/plugins/git/git.plugin.zsh#L63 overwrites / collides with `g`

- git update handling

  - if work tree clean: `git fetch` + `git pull --rebase`
  - if work tree dirty: `git fetch`
 
-  Sort config

   Sort configs alphabetically