### PR TITLE
CI, package updates, 3.10 support, 3.6 deprecation, add precommit

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v1
       - name: Configure git

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Install poetry
         run: |
-          curl -O -sSL https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
-          python install-poetry.py -y --version 1.1.7
+          curl -O -sSL https://install.python-poetry.org/install-poetry.py
+          python install-poetry.py -y --version 1.1.12
           echo "PATH=${HOME}/.poetry/bin:${PATH}" >> $GITHUB_ENV
           rm install-poetry.py
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.7", "3.10"]
     steps:
       - uses: actions/checkout@v1
       - name: Configure git

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Install poetry
         run: |
-          curl -O -sSL https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
-          python install-poetry.py -y --version 1.1.7
+          curl -O -sSL https://install.python-poetry.org/install-poetry.py
+          python install-poetry.py -y --version 1.1.12
           echo "PATH=${HOME}/.poetry/bin:${PATH}" >> $GITHUB_ENV
           rm install-poetry.py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 21.12b0
+    hooks:
+    - id: black
+      language_version: python3.10
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort
+      name: isort (python)
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-poetry 1.1.7
+poetry 1.1.12

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See donation options at <https://git-pull.com/support.html>.
 
 # More information
 
-- Python support: >= 3.6, pypy
+- Python support: >= 3.7, pypy
 - VCS supported: git(1), svn(1), hg(1)
 - Source: <https://github.com/vcs-python/vcspull>
 - Docs: <https://vcspull.git-pull.com>

--- a/poetry.lock
+++ b/poetry.lock
@@ -724,7 +724,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "29a4a4656df4e33f10c3d2511d2d383e5e68d38748f8811b8c0257f083c859a5"
+content-hash = "f6e2d1f32008eea5f712965c220f877b24cc7090717c09ad027d014d0b952344"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -544,17 +544,17 @@ test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "1.12.0"
+version = "1.14.1"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
-Sphinx = ">=3.0"
+Sphinx = ">=4"
 
 [package.extras]
-test = ["pytest (>=3.1.0)", "typing-extensions (>=3.5)", "sphobjinv (>=2.0)", "Sphinx (>=3.2.0)", "dataclasses"]
+testing = ["covdefaults (>=2)", "coverage (>=6)", "diff-cover (>=6.4)", "pytest (>=6)", "pytest-cov (>=3)", "sphobjinv (>=2)", "typing-extensions (>=3.5)"]
 type_comments = ["typed-ast (>=1.4.0)"]
 
 [[package]]
@@ -724,7 +724,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f6e2d1f32008eea5f712965c220f877b24cc7090717c09ad027d014d0b952344"
+content-hash = "b33d7ef657b0e8c7cd50f6ada9cbed8b8652c2dc207d2e37b287545f33d5b74b"
 
 [metadata.files]
 alabaster = [
@@ -1047,8 +1047,8 @@ sphinx = [
     {file = "Sphinx-4.3.1.tar.gz", hash = "sha256:32a5b3e9a1b176cc25ed048557d4d3d01af635e6b76c5bc7a43b0a34447fbd45"},
 ]
 sphinx-autodoc-typehints = [
-    {file = "sphinx-autodoc-typehints-1.12.0.tar.gz", hash = "sha256:193617d9dbe0847281b1399d369e74e34cd959c82e02c7efde077fca908a9f52"},
-    {file = "sphinx_autodoc_typehints-1.12.0-py3-none-any.whl", hash = "sha256:5e81776ec422dd168d688ab60f034fccfafbcd94329e9537712c93003bddc04a"},
+    {file = "sphinx_autodoc_typehints-1.14.1-py3-none-any.whl", hash = "sha256:8b3b7da797fa007f7f39c518879a1bdae3a7dab96e170f4cb5a4b96390238369"},
+    {file = "sphinx_autodoc_typehints-1.14.1.tar.gz", hash = "sha256:875de815a1ba609a4c0ebc620faecd8eb57183ba1f4cc6f8abba1790c140e960"},
 ]
 sphinx-click = [
     {file = "sphinx-click-3.0.2.tar.gz", hash = "sha256:29896dd12bfaacb566a8c7af2e2b675d010d69b0c5aad3b52495d4842358b15b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -60,7 +60,6 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 click = ">=7.1.2"
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
@@ -142,14 +141,6 @@ tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
-
-[[package]]
-name = "dataclasses"
-version = "0.8"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "dev"
-optional = false
-python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "docutils"
@@ -732,8 +723,8 @@ test = []
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "d090eeba76fd04878979e875e2040e94f82b137b443c85da781f84f5eef1ca75"
+python-versions = "^3.7"
+content-hash = "29a4a4656df4e33f10c3d2511d2d383e5e68d38748f8811b8c0257f083c859a5"
 
 [metadata.files]
 alabaster = [
@@ -829,10 +820,6 @@ coverage = [
     {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
     {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
     {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
-]
-dataclasses = [
-    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
-    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -297,18 +297,18 @@ python-versions = "*"
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.2.8"
+version = "0.3.0"
 description = "Collection of plugins for markdown-it-py"
 category = "dev"
 optional = false
 python-versions = "~=3.6"
 
 [package.dependencies]
-markdown-it-py = ">=1.0,<2.0"
+markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
 code_style = ["pre-commit (==2.6)"]
-rtd = ["myst-parser (==0.14.0a3)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
+rtd = ["myst-parser (>=0.14.0,<0.15.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
 testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
 
 [[package]]
@@ -321,7 +321,7 @@ python-versions = "*"
 
 [[package]]
 name = "myst-parser"
-version = "0.15.2"
+version = "0.16.1"
 description = "An extended commonmark compliant parser, with bridges to docutils & sphinx."
 category = "dev"
 optional = false
@@ -330,8 +330,8 @@ python-versions = ">=3.6"
 [package.dependencies]
 docutils = ">=0.15,<0.18"
 jinja2 = "*"
-markdown-it-py = ">=1.0.0,<2.0.0"
-mdit-py-plugins = ">=0.2.8,<0.3.0"
+markdown-it-py = ">=1.0.0,<3.0.0"
+mdit-py-plugins = ">=0.3.0,<0.4.0"
 pyyaml = "*"
 sphinx = ">=3.1,<5"
 
@@ -733,7 +733,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "25984bfeeb53e4852a597046a8c1b3855a51c3ac66cd05b4c90021d43a0a9e82"
+content-hash = "d090eeba76fd04878979e875e2040e94f82b137b443c85da781f84f5eef1ca75"
 
 [metadata.files]
 alabaster = [
@@ -953,16 +953,16 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mdit-py-plugins = [
-    {file = "mdit-py-plugins-0.2.8.tar.gz", hash = "sha256:5991cef645502e80a5388ec4fc20885d2313d4871e8b8e320ca2de14ac0c015f"},
-    {file = "mdit_py_plugins-0.2.8-py3-none-any.whl", hash = "sha256:1833bf738e038e35d89cb3a07eb0d227ed647ce7dd357579b65343740c6d249c"},
+    {file = "mdit-py-plugins-0.3.0.tar.gz", hash = "sha256:ecc24f51eeec6ab7eecc2f9724e8272c2fb191c2e93cf98109120c2cace69750"},
+    {file = "mdit_py_plugins-0.3.0-py3-none-any.whl", hash = "sha256:b1279701cee2dbf50e188d3da5f51fee8d78d038cdf99be57c6b9d1aa93b4073"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 myst-parser = [
-    {file = "myst-parser-0.15.2.tar.gz", hash = "sha256:f7f3b2d62db7655cde658eb5d62b2ec2a4631308137bd8d10f296a40d57bbbeb"},
-    {file = "myst_parser-0.15.2-py3-none-any.whl", hash = "sha256:40124b6f27a4c42ac7f06b385e23a9dcd03d84801e9c7130b59b3729a554b1f9"},
+    {file = "myst-parser-0.16.1.tar.gz", hash = "sha256:a6473b9735c8c74959b49b36550725464f4aecc4481340c9a5f9153829191f83"},
+    {file = "myst_parser-0.16.1-py3-none-any.whl", hash = "sha256:617a90ceda2162ebf81cd13ad17d879bd4f49e7fb5c4f177bb905272555a2268"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ sphinx = "*"
 alagitpull = "^0.1.0"
 sphinx-issues = "^1.2.0"
 sphinx-click = "*"
-sphinx-autodoc-typehints = "^1.12.0"
+sphinx-autodoc-typehints = "~1.14.1"
 myst_parser = "~0.16.1"
 
 ### Testing ###

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ alagitpull = "^0.1.0"
 sphinx-issues = "^1.2.0"
 sphinx-click = "*"
 sphinx-autodoc-typehints = "^1.12.0"
-myst_parser = "^0.15.0"
+myst_parser = "~0.16.1"
 
 ### Testing ###
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ homepage = "https://vcspull.git-pull.com"
 "Bug Tracker" = "https://github.com/vcs-python/vcspull/issues"
 Documentation = "https://vcspull.git-pull.com"
 Repository = "https://github.com/vcs-python/vcspull"
+Changes = "https://github.com/vcs-python/vcspull/blob/master/CHANGES"
 
 [tool.poetry.scripts]
 vcspull = 'vcspull:cli.cli'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
   "Operating System :: MacOS :: MacOS X",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,7 @@ test = ["pytest", "pytest-rerunfailures"]
 coverage = ["codecov", "coverage", "pytest-cov"]
 format = ["black", "isort"]
 lint = ["flake8"]
+
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ coverage = "*"
 pytest-cov = "*"
 
 ### Format ###
-black = {version="==21.12b0"}
+black = "==21.12b0"
 isort = "*"
 
 ### Lint ###

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ Changes = "https://github.com/vcs-python/vcspull/blob/master/CHANGES"
 vcspull = 'vcspull:cli.cli'
 
 [tool.poetry.dependencies]
-python = "^3.6"
-click = ">=7<8"
+python = "^3.7"
+click = ">=7<8.1"
 kaptan = "*"
 libvcs = "~0.10.1"
 colorama = ">=0.3.9"
@@ -66,7 +66,7 @@ coverage = "*"
 pytest-cov = "*"
 
 ### Format ###
-black = {version="==21.12b0", python="^3.6.2"}
+black = {version="==21.12b0"}
 isort = "*"
 
 ### Lint ###


### PR DESCRIPTION
- poetry 1.1.7 -> 1.1.12, use new installer
- Drop python 3.6
- Add python 3.10
- CI: test 3.7 and 3.10 (low and high end of supported releases)
- Update myst-parser and sphinx-autodoc-typehints
- Add `.pre-commit-config.yaml`
- black: update 21.9b0 -> 21.12b0