### PR TITLE
Fix simplified remote rewrite

### DIFF
--- a/vcspull/cli/sync.py
+++ b/vcspull/cli/sync.py
@@ -128,12 +128,13 @@ def update_repo(repo_dict):
     if remote_settings.get("origin", {}) == {}:
         from libvcs.git import GitRemote
 
+        remote_url = repo_dict["pip_url"].replace("git+", "")
+
         remote_settings["origin"] = GitRemote(
             name="origin",
-            push_url=repo_dict["pip_url"],
-            fetch_url=repo_dict["pip_url"],
+            push_url=remote_url,
+            fetch_url=remote_url,
         )
-
     remotes_updated = False
     r.update_repo()  # Creates repo if not exists and fetches
 
@@ -141,6 +142,11 @@ def update_repo(repo_dict):
         config_remote_name = remote_name  # From config file
         try:
             current_remote = r.remote(config_remote_name)
+            if current_remote is not None:
+                current_remote._replace(
+                    fetch_url=current_remote.fetch_url.replace("git+", "")
+                )
+
         except FileNotFoundError:  # git repo doesn't exist yet, so cna't be outdated
             break
 


### PR DESCRIPTION
#332

- tests: Capture stdout messages for updating remotes
- tests: Extract sync tests to test_sync.py
- tests: rename test_repo_object.py to test_repo.py