### PR TITLE
refactor!: Move to `XDG_CONFIG_HOME`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,17 @@ $ pipx install --suffix=@next 'vcspull' --pip-args '\--pre' --force
 
 ## current - unrelased
 
+### Breaking changes
+
+- Config location uses `XDG_CONFIG_HOME` from [XDG Base Directory],
+  ({issue}`#367`).
+
+  Old path: `~/.vcspull`
+
+  New path: `XDG_CONFIG_HOME`, usually `~/.config/vcspull`
+
+  [xdg base directory]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
 ### Compatibility
 
 - Python 3.7 and 3.8 dropped (#356)

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -201,7 +201,9 @@ def test_multiple_config_files_raises_exception(tmp_path: pathlib.Path):
 
 
 def test_in_dir(
-    config_path: pathlib.Path, yaml_config: pathlib.Path, json_config: pathlib.Path
+    config_path: pathlib.Path,
+    yaml_config: pathlib.Path,
+    json_config: pathlib.Path,
 ):
     expected = [yaml_config.stem, json_config.stem]
     result = config.in_dir(str(config_path))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import pathlib
+
+import pytest
+
+from vcspull.util import get_config_dir
+
+
+def test_vcspull_configdir_env_var(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("VCSPULL_CONFIGDIR", str(tmp_path))
+
+    assert get_config_dir() == tmp_path
+
+
+def test_vcspull_configdir_xdg_config_dir(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    vcspull_dir = tmp_path / "vcspull"
+    vcspull_dir.mkdir()
+
+    assert get_config_dir() == vcspull_dir
+
+
+def test_vcspull_configdir_no_xdg(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+    assert get_config_dir()

--- a/vcspull/config.py
+++ b/vcspull/config.py
@@ -15,7 +15,7 @@ import kaptan
 from libvcs.states.git import GitRemote
 
 from . import exc
-from .util import CONFIG_DIR, update_dict
+from .util import get_config_dir, update_dict
 
 log = logging.getLogger(__name__)
 
@@ -132,7 +132,7 @@ def find_home_config_files(filetype=["json", "yaml"]):
 
 
 def find_config_files(
-    path=["~/.vcspull"], match=["*"], filetype=["json", "yaml"], include_home=False
+    path=None, match=["*"], filetype=["json", "yaml"], include_home=False
 ):
     """Return repos from a directory and match. Not recursive.
 
@@ -158,6 +158,8 @@ def find_config_files(
         list of absolute paths to config files.
     """
     configs = []
+    if path is None:
+        path = get_config_dir()
 
     if include_home is True:
         configs.extend(find_home_config_files())
@@ -264,7 +266,7 @@ def detect_duplicate_repos(repos1, repos2):
     return dupes
 
 
-def in_dir(config_dir=CONFIG_DIR, extensions=[".yml", ".yaml", ".json"]):
+def in_dir(config_dir=None, extensions=[".yml", ".yaml", ".json"]):
     """Return a list of configs in ``config_dir``.
 
     Parameters
@@ -278,6 +280,8 @@ def in_dir(config_dir=CONFIG_DIR, extensions=[".yml", ".yaml", ".json"]):
     -------
     list
     """
+    if config_dir is not None:
+        config_dir = get_config_dir()
     configs = []
 
     for filename in os.listdir(config_dir):

--- a/vcspull/util.py
+++ b/vcspull/util.py
@@ -5,9 +5,44 @@ vcspull.util
 
 """
 import os
+import pathlib
 from collections.abc import Mapping
 
-CONFIG_DIR = os.path.expanduser("~/.vcspull/")  # remove dupes of this
+LEGACY_CONFIG_DIR = os.path.expanduser("~/.vcspull/")  # remove dupes of this
+
+
+def get_config_dir() -> pathlib.Path:
+    """
+    Return vcspull configuration directory.
+
+    ``VCSPULL_CONFIGDIR`` environmental variable has precedence if set. We also
+    evaluate XDG default directory from XDG_CONFIG_HOME environmental variable
+    if set or its default. Then the old default ~/.vcspull is returned for
+    compatibility.
+
+    Returns
+    -------
+    str :
+        absolute path to tmuxp config directory
+    """
+
+    paths = []
+    if "VCSPULL_CONFIGDIR" in os.environ:
+        paths.append(os.environ["VCSPULL_CONFIGDIR"])
+    if "XDG_CONFIG_HOME" in os.environ:
+        paths.append(os.path.join(os.environ["XDG_CONFIG_HOME"], "vcspull"))
+    else:
+        paths.append("~/.config/vcspull/")
+    paths.append(LEGACY_CONFIG_DIR)
+
+    path = None
+    for path in paths:
+        path = os.path.expanduser(path)
+        if os.path.isdir(path):
+            return pathlib.Path(path)
+
+    # Return last path as default if none of the previous ones matched
+    return pathlib.Path(path)
 
 
 def update_dict(d, u):


### PR DESCRIPTION
- New default config dir is XDG_CONFIG_HOME, Usually ~/.config/vcspull
- Custom config via VCSPULL_CONFIGDIR
- Legacy support until deprecated via LEGACY_CONFIG_DIR (subject to
  being removed in future releases)