### PR TITLE
docs: Move to sphinx-autoissues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,10 @@ $ pipx install --suffix=@next 'vcspull' --pip-args '\--pre' --force
 - Remove `.pre-commit-config.yaml`: Let's not automate what the contributor could /
   should do themselves.
 
+### Documentation
+
+- Render changelog in sphinx-autoissues (#378)
+
 ### Bug fixes
 
 - Fix cloning of mercurial repositories

--- a/CHANGES
+++ b/CHANGES
@@ -63,7 +63,7 @@ Patch branch: [`v1.12.x`](https://github.com/vcs-python/vcspull/tree/v1.12.x)
 ### Breaking changes
 
 - Config location uses `XDG_CONFIG_HOME` from [XDG Base Directory],
-  ({issue}`367`).
+  (#367).
 
   Old path: `~/.vcspull`
 
@@ -71,13 +71,13 @@ Patch branch: [`v1.12.x`](https://github.com/vcs-python/vcspull/tree/v1.12.x)
 
   [xdg base directory]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 
-- Override config directory via `VCSPULL_CONFIGDIR` ({issue}`367`)
-- Switch from `str` to `pathlib.Path` ({issue}`364`)
+- Override config directory via `VCSPULL_CONFIGDIR` (#367)
+- Switch from `str` to `pathlib.Path` (#364)
 - Requires click 8+
 
 ### Compatibility
 
-- Allow click 8.1.x ({issue}`372`)
+- Allow click 8.1.x (#372)
 - vcspull learned `-h` for help (thanks HN 2022-04-11)
 - Python 3.7 and 3.8 dropped (#356)
 
@@ -118,7 +118,7 @@ Patch branch: [`v1.12.x`](https://github.com/vcs-python/vcspull/tree/v1.12.x)
 
 ### Compatibility
 
-- Allow click 8.1.x (backport of {issue}`372`)
+- Allow click 8.1.x (backport of #372)
 
 ## vcspull 1.11.3 (2022-04-11)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.napoleon",
     "sphinx.ext.linkcode",
-    "sphinx_issues",
+    "sphinx_autoissues",
     "sphinx_click.ext",  # sphinx-click
     "sphinx_inline_tabs",
     "sphinx_copybutton",
@@ -83,6 +83,10 @@ html_sidebars = {
     ]
 }
 
+# sphinx-autoissues
+issuetracker = "github"
+issuetracker_project = "vcs-python/vcspull"
+
 # sphinx.ext.autodoc
 autoclass_content = "both"
 autodoc_member_order = "bysource"
@@ -108,9 +112,6 @@ copybutton_prompt_text = (
 )
 copybutton_prompt_is_regexp = True
 copybutton_remove_prompts = True
-
-# sphinx-issues
-issues_github_path = "vcs-python/vcspull"
 
 # sphinxext-rediraffe
 rediraffe_redirects = "redirects.txt"

--- a/poetry.lock
+++ b/poetry.lock
@@ -700,6 +700,14 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "diff-cover (>=6.5.1)", 
 type_comments = ["typed-ast (>=1.5.4)"]
 
 [[package]]
+name = "sphinx-autoissues"
+version = "0.0.1"
+description = "Sphinx integration with different issuetrackers"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "sphinx-basic-ng"
 version = "0.0.1a12"
 description = "A modern skeleton for Sphinx themes."
@@ -951,7 +959,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "955eeb99ef6c83aca8010667eebeaa1975d786947e35dab5960265bfc48959f8"
+content-hash = "adfd111b9136c6ab568d3ff63f858ad0c6ab200c0d98ed856f285905a2872c45"
 
 [metadata.files]
 alabaster = [
@@ -1369,6 +1377,10 @@ sphinx-autobuild = [
 sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.19.2-py3-none-any.whl", hash = "sha256:3d761de928d5a86901331133d6d4a2552afa2e798ebcfc0886791792aeb4dd9a"},
     {file = "sphinx_autodoc_typehints-1.19.2.tar.gz", hash = "sha256:872fb2d7b3d794826c28e36edf6739e93549491447dcabeb07c58855e9f914de"},
+]
+sphinx-autoissues = [
+    {file = "sphinx-autoissues-0.0.1.tar.gz", hash = "sha256:a308fd914d700ff2aa2b4584c29975a030ede7171898130ec816eca7ec2c8ce8"},
+    {file = "sphinx_autoissues-0.0.1-py3-none-any.whl", hash = "sha256:07503b774c3a64b97d2614fa409410316fbfeb87ba4553dbe3a7d2131b7453a0"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a12-py3-none-any.whl", hash = "sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -765,22 +765,6 @@ doc = ["furo", "myst-parser"]
 test = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "sphinx-issues"
-version = "3.0.1"
-description = "A Sphinx extension for linking to your project's issue tracker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-dev = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)", "pytest (>=6.2.0)", "tox"]
-lint = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)"]
-tests = ["pytest (>=6.2.0)"]
-
-[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
@@ -959,7 +943,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "adfd111b9136c6ab568d3ff63f858ad0c6ab200c0d98ed856f285905a2872c45"
+content-hash = "24f513b49a8c7c2d1f4aa69b86c934fb38ce0b31c1d19e337d09f1febe5c5df7"
 
 [metadata.files]
 alabaster = [
@@ -1397,10 +1381,6 @@ sphinx-copybutton = [
 sphinx-inline-tabs = [
     {file = "sphinx_inline_tabs-2022.1.2b11-py3-none-any.whl", hash = "sha256:bb4e807769ef52301a186d0678da719120b978a1af4fd62a1e9453684e962dbc"},
     {file = "sphinx_inline_tabs-2022.1.2b11.tar.gz", hash = "sha256:afb9142772ec05ccb07f05d8181b518188fc55631b26ee803c694e812b3fdd73"},
-]
-sphinx-issues = [
-    {file = "sphinx-issues-3.0.1.tar.gz", hash = "sha256:b7c1dc1f4808563c454d11c1112796f8c176cdecfee95f0fd2302ef98e21e3d6"},
-    {file = "sphinx_issues-3.0.1-py3-none-any.whl", hash = "sha256:8b25dc0301159375468f563b3699af7a63720fd84caf81c1442036fcd418b20c"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ sphinx-inline-tabs = "*"
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
 sphinxext-rediraffe = "*"
+sphinx-autoissues = "*"
 myst_parser = "*"
 
 ### Testing ###
@@ -103,6 +104,7 @@ docs = [
   "sphinx-autobuild",
   "sphinxext-rediraffe",
   "sphinx-copybutton",
+  "sphinx-autoissues",
   "sphinxext-opengraph",
   "sphinx-inline-tabs",
   "myst_parser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ sphinx-autoapi = "*"
 sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"
 sphinx-click = "*"
-sphinx-issues = "*"
 sphinx-inline-tabs = "*"
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
@@ -97,7 +96,6 @@ mypy = "*"
 [tool.poetry.extras]
 docs = [
   "sphinx",
-  "sphinx-issues",
   "sphinx-click",
   "sphinx-autoapi",
   "sphinx-autodoc-typehints",


### PR DESCRIPTION
https://github.com/tony/sphinx-autoissues ([Homepage](https://sphinx-autoissues.git-pull.com/))

This is a fork of [sphinxcontrib-issuetracker](https://github.com/lunaryorn/sphinxcontrib-issuetracker) but heavily modified. In the end the similarities between the packages may be less: But the major point is we want plain text issues to be linked