### PR TITLE
CLI: Naming cleanup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,10 @@ $ pipx install --suffix=@next 'vcspull' --pip-args '\--pre' --force
 
 <!-- Maintainers, insert changes / features for the next release here -->
 
+### CLI
+
+- Copy updates and metavar updates for `vcspull sync` (#404)
+
 ## vcspull v1.15.4 (2022-10-16)
 
 ### CLI

--- a/src/vcspull/cli/__init__.py
+++ b/src/vcspull/cli/__init__.py
@@ -48,7 +48,7 @@ def cli(args=None):
         return
     elif args.subparser_name == "sync":
         sync(
-            repo_terms=args.repo_terms,
+            repo_pattern=args.repo_pattern,
             config=args.config,
             exit_on_error=args.exit_on_error,
             parser=parser,

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -38,7 +38,7 @@ def create_sync_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         "-x",
         action="store_true",
         dest="exit_on_error",
-        help="exit immediately when encountering an error syncing multiple repos",
+        help="exit immediately encountering error (when syncing multiple repos)",
     )
     try:
         import shtab

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -23,9 +23,10 @@ NO_REPOS_FOR_TERM_MSG = 'No repo found in config(s) for "{name}"'
 def create_sync_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     config_file = parser.add_argument("--config", "-c", help="specify config")
     parser.add_argument(
-        "repo_terms",
+        "repo_pattern",
+        metavar="filter",
         nargs="+",
-        help="filter(s) of repo terms, separated by spaces, accepts globs / fnmatch(3)",
+        help="patterns / terms of repos, accepts globs / fnmatch(3)",
     )
     parser.add_argument(
         "--exit-on-error",
@@ -44,7 +45,7 @@ def create_sync_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
 
 
 def sync(
-    repo_terms,
+    repo_pattern,
     config,
     exit_on_error: bool,
     parser: t.Optional[
@@ -57,14 +58,14 @@ def sync(
         configs = load_configs(find_config_files(include_home=True))
     found_repos = []
 
-    for repo_term in repo_terms:
+    for repo_pattern in repo_pattern:
         dir, vcs_url, name = None, None, None
-        if any(repo_term.startswith(n) for n in ["./", "/", "~", "$HOME"]):
-            dir = repo_term
-        elif any(repo_term.startswith(n) for n in ["http", "git", "svn", "hg"]):
-            vcs_url = repo_term
+        if any(repo_pattern.startswith(n) for n in ["./", "/", "~", "$HOME"]):
+            dir = repo_pattern
+        elif any(repo_pattern.startswith(n) for n in ["http", "git", "svn", "hg"]):
+            vcs_url = repo_pattern
         else:
-            name = repo_term
+            name = repo_pattern
 
         # collect the repos from the config files
         found = filter_repos(configs, dir=dir, vcs_url=vcs_url, name=name)

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -25,7 +25,7 @@ def create_sync_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     parser.add_argument(
         "repo_terms",
         nargs="+",
-        help="filters: repo terms, separated by spaces, supports globs / fnmatch (1)",
+        help="filter(s) of repo terms, separated by spaces, accepts globs / fnmatch(3)",
     )
     parser.add_argument(
         "--exit-on-error",

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -21,7 +21,12 @@ NO_REPOS_FOR_TERM_MSG = 'No repo found in config(s) for "{name}"'
 
 
 def create_sync_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    config_file = parser.add_argument("--config", "-c", help="specify config")
+    config_file = parser.add_argument(
+        "--config",
+        "-c",
+        metavar="config-file",
+        help="optional filepath to specify vcspull config",
+    )
     parser.add_argument(
         "repo_pattern",
         metavar="filter",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ SYNC_CLI_EXISTENT_REPO_FIXTURES = [
     SYNC_CLI_EXISTENT_REPO_FIXTURES,
     ids=[test.test_id for test in SYNC_CLI_EXISTENT_REPO_FIXTURES],
 )
-def test_sync_cli_repo_term_non_existent(
+def test_sync_cli_filter_non_existent(
     tmp_path: pathlib.Path,
     capsys: pytest.CaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
@@ -158,9 +158,7 @@ SYNC_REPO_FIXTURES = [
         test_id="sync--empty",
         sync_args=["sync"],
         expected_exit_code=1,
-        expected_in_out=(
-            "sync: error: the following arguments are required: repo_terms"
-        ),
+        expected_in_out=("sync: error: the following arguments are required: filter"),
         expected_not_in_out="positional arguments:",
     ),
     # Sync: Help
@@ -168,14 +166,14 @@ SYNC_REPO_FIXTURES = [
         test_id="sync---help",
         sync_args=["sync", "--help"],
         expected_exit_code=0,
-        expected_in_out=["repo_terms", "--exit-on-error"],
+        expected_in_out=["filter", "--exit-on-error"],
         expected_not_in_out="--version",
     ),
     SyncFixture(
         test_id="sync--h",
         sync_args=["sync", "-h"],
         expected_exit_code=0,
-        expected_in_out=["repo_terms", "--exit-on-error"],
+        expected_in_out=["filter", "--exit-on-error"],
         expected_not_in_out="--version",
     ),
     # Sync: Repo terms


### PR DESCRIPTION
Purely copy tweaks, except for `sync`, which has a kwarg update.

Since `sync()` has a param change, even though its an internal API, I will bump version for this