### PR TITLE
fix(cli[sync]): Fix vcspull sync with no args

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,12 @@ $ pipx install --suffix=@next 'vcspull' --pip-args '\--pre' --force
 
 <!-- Maintainers, insert changes / features for the next release here -->
 
+## vcspull v1.15.5 (unreleased)
+
+### CLI
+
+- `vcspull sync`: Fix showing of help when no arguments passed (#405)
+
 ## vcspull v1.15.4 (2022-10-16)
 
 ### CLI

--- a/src/vcspull/cli/__init__.py
+++ b/src/vcspull/cli/__init__.py
@@ -30,6 +30,7 @@ def create_parser():
         default="INFO",
         help="log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
     )
+
     subparsers = parser.add_subparsers(dest="subparser_name")
     sync_parser = subparsers.add_parser("sync", help="synchronize repos")
     create_sync_subparser(sync_parser)

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -24,7 +24,7 @@ def create_sync_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     config_file = parser.add_argument("--config", "-c", help="specify config")
     parser.add_argument(
         "repo_terms",
-        nargs="+",
+        nargs="*",
         help="filters: repo terms, separated by spaces, supports globs / fnmatch (1)",
     )
     parser.add_argument(
@@ -34,6 +34,7 @@ def create_sync_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         dest="exit_on_error",
         help="exit immediately when encountering an error syncing multiple repos",
     )
+
     try:
         import shtab
 
@@ -51,6 +52,11 @@ def sync(
         argparse.ArgumentParser
     ] = None,  # optional so sync can be unit tested
 ) -> None:
+    if isinstance(repo_terms, list) and len(repo_terms) == 0:
+        if parser is not None:
+            parser.print_help()
+        sys.exit(2)
+
     if config:
         configs = load_configs([config])
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,11 +157,8 @@ SYNC_REPO_FIXTURES = [
     SyncFixture(
         test_id="sync--empty",
         sync_args=["sync"],
-        expected_exit_code=1,
-        expected_in_out=(
-            "sync: error: the following arguments are required: repo_terms"
-        ),
-        expected_not_in_out="positional arguments:",
+        expected_exit_code=0,
+        expected_in_out=["positional arguments:"],
     ),
     # Sync: Help
     SyncFixture(


### PR DESCRIPTION
Fix `vcspull sync` behavior when no arguments passed