### PR TITLE
libvcs 0.19.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,15 @@ $ pipx install --suffix=@next 'vcspull' --pip-args '\--pre' --force
 
 <!-- Maintainers, insert changes / features for the next release here -->
 
+**Maintenance release, no features or fixes**
+
+### Internal
+
+- Bump libvcs 0.18.1 -> 0.19.0 (#408)
+
+  Refactor of sync and commands. Syncing now uses commands instead of invoking
+  directly through `run()`.
+
 ## vcspull v1.16.0 (2022-10-23)
 
 **Maintenance release, no features or fixes**

--- a/poetry.lock
+++ b/poetry.lock
@@ -275,7 +275,7 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "libvcs"
-version = "0.18.1"
+version = "0.19.0"
 description = "Lite, typed, python utilities for Git, SVN, Mercurial, etc."
 category = "main"
 optional = false
@@ -944,7 +944,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "5968e4ca0807027f438751d44bb8fd0a3980e12199553396bef73340c2fa34ac"
+content-hash = "68008b46b2191d82b67b3ad4aea57ddeddb9b2ce57994e4681bce7bf319d461c"
 
 [metadata.files]
 alabaster = [
@@ -1107,8 +1107,8 @@ Jinja2 = [
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
 libvcs = [
-    {file = "libvcs-0.18.1-py3-none-any.whl", hash = "sha256:bf1e8f6e4c0d66ccd20bce5fc2f044db9520dc32aea25df3f68becabc0513577"},
-    {file = "libvcs-0.18.1.tar.gz", hash = "sha256:84302304df69356678408c148dd1dda3f752cebc09a21fe4f47a59d9a3c7ae46"},
+    {file = "libvcs-0.19.0-py3-none-any.whl", hash = "sha256:9f915caf9354e08249112a19b73f056a7bce033cb96a2d91bbf995d5fc3192a1"},
+    {file = "libvcs-0.19.0.tar.gz", hash = "sha256:bfdc2c91527c340fb290754724d50c053dfd9b1bdd9262639d9253b79e6d27af"},
 ]
 livereload = [
     {file = "livereload-2.6.3.tar.gz", hash = "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"},
@@ -1269,6 +1269,13 @@ PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ vcspull = 'vcspull:cli.cli'
 
 [tool.poetry.dependencies]
 python = "^3.9"
-libvcs = "~0.18.1"
+libvcs = "~0.19.0"
 colorama = ">=0.3.9"
 PyYAML = "^6.0"
 


### PR DESCRIPTION
To include the massive (internal) refactor from https://github.com/vcs-python/libvcs/pull/430

- build(deps): Bump libvcs 0.18.x -> 0.19.x (sync refactor)