### PR TITLE
tests(config-variations): Git schemes in repo URLs

### DIFF
--- a/src/vcspull/__init__.py
+++ b/src/vcspull/__init__.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 import logging
 from logging import NullHandler
 
-from . import cli
+from . import (
+    cli,
+    url,  # Import custom URL handling
+)
 
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/vcspull/__init__.py
+++ b/src/vcspull/__init__.py
@@ -11,9 +11,7 @@ from __future__ import annotations
 import logging
 from logging import NullHandler
 
-from . import (
-    cli,
-    url,  # Import custom URL handling
-)
+from . import cli
+from .url import enable_ssh_style_url_detection  # Import custom URL handling
 
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -12,6 +12,7 @@ from libvcs.url import registry as url_tools
 
 from vcspull import exc
 from vcspull.config import filter_repos, find_config_files, load_configs
+from vcspull.url import enable_ssh_style_url_detection
 
 if t.TYPE_CHECKING:
     import argparse
@@ -147,6 +148,8 @@ def update_repo(
     # repo_dict: Dict[str, Union[str, Dict[str, GitRemote], pathlib.Path]]
 ) -> GitSync:
     """Synchronize a single repository."""
+    # Ensure SSH-style URLs are recognized as explicit Git URLs
+    enable_ssh_style_url_detection()
     repo_dict = deepcopy(repo_dict)
     if "pip_url" not in repo_dict:
         repo_dict["pip_url"] = repo_dict.pop("url")

--- a/src/vcspull/url.py
+++ b/src/vcspull/url.py
@@ -1,0 +1,13 @@
+"""URL handling for vcspull."""
+
+from __future__ import annotations
+
+from libvcs.url.git import DEFAULT_RULES
+
+# Find the core-git-scp rule and modify it to be explicit
+for rule in DEFAULT_RULES:
+    if rule.label == "core-git-scp":
+        # Make the rule explicit so it can be detected with is_explicit=True
+        rule.is_explicit = True
+        # Increase the weight to ensure it takes precedence
+        rule.weight = 100

--- a/src/vcspull/url.py
+++ b/src/vcspull/url.py
@@ -4,10 +4,71 @@ from __future__ import annotations
 
 from libvcs.url.git import DEFAULT_RULES
 
-# Find the core-git-scp rule and modify it to be explicit
-for rule in DEFAULT_RULES:
-    if rule.label == "core-git-scp":
-        # Make the rule explicit so it can be detected with is_explicit=True
-        rule.is_explicit = True
-        # Increase the weight to ensure it takes precedence
-        rule.weight = 100
+
+def enable_ssh_style_url_detection() -> None:
+    """Enable detection of SSH-style URLs as explicit Git URLs.
+
+    This makes the core-git-scp rule explicit, which allows URLs like
+    'user@hostname:path/to/repo.git' to be detected with is_explicit=True.
+
+    Examples
+    --------
+        >>> from vcspull.url import enable_ssh_style_url_detection
+        >>> from libvcs.url.git import GitURL
+        >>> # Without the patch
+        >>> GitURL.is_valid('user@hostname:path/to/repo.git', is_explicit=True)
+        False
+        >>> # With the patch
+        >>> enable_ssh_style_url_detection()
+        >>> GitURL.is_valid('user@hostname:path/to/repo.git', is_explicit=True)
+        True
+    """
+    for rule in DEFAULT_RULES:
+        if rule.label == "core-git-scp":
+            # Make the rule explicit so it can be detected with is_explicit=True
+            rule.is_explicit = True
+            # Increase the weight to ensure it takes precedence
+            rule.weight = 100
+
+
+def disable_ssh_style_url_detection() -> None:
+    """Disable detection of SSH-style URLs as explicit Git URLs.
+
+    This reverts the core-git-scp rule to its original state, where URLs like
+    'user@hostname:path/to/repo.git' are not detected with is_explicit=True.
+
+    Examples
+    --------
+        >>> from vcspull.url import enable_ssh_style_url_detection, disable_ssh_style_url_detection
+        >>> from libvcs.url.git import GitURL
+        >>> # Enable the patch
+        >>> enable_ssh_style_url_detection()
+        >>> GitURL.is_valid('user@hostname:path/to/repo.git', is_explicit=True)
+        True
+        >>> # Disable the patch
+        >>> disable_ssh_style_url_detection()
+        >>> GitURL.is_valid('user@hostname:path/to/repo.git', is_explicit=True)
+        False
+    """
+    for rule in DEFAULT_RULES:
+        if rule.label == "core-git-scp":
+            # Revert to original state
+            rule.is_explicit = False
+            rule.weight = 0
+
+
+def is_ssh_style_url_detection_enabled() -> bool:
+    """Check if SSH-style URL detection is enabled.
+
+    Returns
+    -------
+        bool: True if SSH-style URL detection is enabled, False otherwise.
+    """
+    for rule in DEFAULT_RULES:
+        if rule.label == "core-git-scp":
+            return rule.is_explicit
+    return False
+
+
+# Enable SSH-style URL detection by default
+enable_ssh_style_url_detection()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -133,6 +133,35 @@ CONFIG_VARIATION_FIXTURES: list[ConfigVariationTest] = [
         """,
         remote_list=["git_scheme_repo"],
     ),
+    ConfigVariationTest(
+        test_id="expanded_repo_style_with_unprefixed_remote_3",
+        config_tpl="""
+        {tmp_path}/study/myrepo:
+            {CLONE_NAME}:
+                repo: git+file://{dir}
+                remotes:
+                  git_scheme_repo: user@myhostname.de:org/repo.git
+        """,
+        remote_list=["git_scheme_repo"],
+    ),
+    ConfigVariationTest(
+        test_id="expanded_repo_style_with_unprefixed_repo",
+        config_tpl="""
+        {tmp_path}/study/myrepo:
+            {CLONE_NAME}:
+                repo: user@myhostname.de:org/repo.git
+        """,
+        remote_list=["git_scheme_repo"],
+    ),
+    ConfigVariationTest(
+        test_id="expanded_repo_style_with_prefixed_repo_3_with_prefix",
+        config_tpl="""
+        {tmp_path}/study/myrepo:
+            {CLONE_NAME}:
+                repo: git+ssh://user@myhostname.de:org/repo.git
+        """,
+        remote_list=["git_scheme_repo"],
+    ),
 ]
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -138,7 +138,7 @@ CONFIG_VARIATION_FIXTURES: list[ConfigVariationTest] = [
         config_tpl="""
         {tmp_path}/study/myrepo:
             {CLONE_NAME}:
-                repo: git+file://{dir}
+                repo: git+file://{path}
                 remotes:
                   git_scheme_repo: user@myhostname.de:org/repo.git
         """,

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,0 +1,62 @@
+"""Tests for URL handling in vcspull."""
+
+from __future__ import annotations
+
+import pytest
+from libvcs.url.git import GitURL
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "user@myhostname.de:org/repo.git",
+        "git@github.com:vcs-python/vcspull.git",
+        "git@gitlab.com:vcs-python/vcspull.git",
+        "user@custom-host.com:path/to/repo.git",
+    ],
+)
+def test_ssh_style_url_detection(url: str) -> None:
+    """Test that SSH-style URLs are correctly detected."""
+    assert GitURL.is_valid(url)
+    git_url = GitURL(url)
+    assert git_url.rule == "core-git-scp"
+
+
+@pytest.mark.parametrize(
+    "url,expected_user,expected_hostname,expected_path",
+    [
+        (
+            "user@myhostname.de:org/repo.git",
+            "user",
+            "myhostname.de",
+            "org/repo",
+        ),
+        (
+            "git@github.com:vcs-python/vcspull.git",
+            "git",
+            "github.com",
+            "vcs-python/vcspull",
+        ),
+        (
+            "git@gitlab.com:vcs-python/vcspull.git",
+            "git",
+            "gitlab.com",
+            "vcs-python/vcspull",
+        ),
+        (
+            "user@custom-host.com:path/to/repo.git",
+            "user",
+            "custom-host.com",
+            "path/to/repo",
+        ),
+    ],
+)
+def test_ssh_style_url_parsing(
+    url: str, expected_user: str, expected_hostname: str, expected_path: str
+) -> None:
+    """Test that SSH-style URLs are correctly parsed."""
+    git_url = GitURL(url)
+    assert git_url.user == expected_user
+    assert git_url.hostname == expected_hostname
+    assert git_url.path == expected_path
+    assert git_url.suffix == ".git"

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -5,6 +5,38 @@ from __future__ import annotations
 import pytest
 from libvcs.url.git import GitURL
 
+from vcspull.url import disable_ssh_style_url_detection, enable_ssh_style_url_detection
+
+
+def test_ssh_style_url_detection_toggle() -> None:
+    """Test that SSH-style URL detection can be toggled on and off."""
+    url = "user@myhostname.de:org/repo.git"
+
+    # First, disable the detection
+    disable_ssh_style_url_detection()
+
+    # Without the patch, SSH-style URLs should not be detected as explicit
+    assert GitURL.is_valid(url)  # Should be valid in non-explicit mode
+    assert not GitURL.is_valid(
+        url, is_explicit=True
+    )  # Should not be valid in explicit mode
+
+    # Now enable the detection
+    enable_ssh_style_url_detection()
+
+    # With the patch, SSH-style URLs should be detected as explicit
+    assert GitURL.is_valid(url)  # Should still be valid in non-explicit mode
+    assert GitURL.is_valid(
+        url, is_explicit=True
+    )  # Should now be valid in explicit mode
+
+    # Verify the rule used
+    git_url = GitURL(url)
+    assert git_url.rule == "core-git-scp"
+
+    # Re-enable for other tests
+    enable_ssh_style_url_detection()
+
 
 @pytest.mark.parametrize(
     "url",
@@ -17,7 +49,11 @@ from libvcs.url.git import GitURL
 )
 def test_ssh_style_url_detection(url: str) -> None:
     """Test that SSH-style URLs are correctly detected."""
+    # Ensure detection is enabled
+    enable_ssh_style_url_detection()
+
     assert GitURL.is_valid(url)
+    assert GitURL.is_valid(url, is_explicit=True)  # Should be valid in explicit mode
     git_url = GitURL(url)
     assert git_url.rule == "core-git-scp"
 
@@ -55,6 +91,9 @@ def test_ssh_style_url_parsing(
     url: str, expected_user: str, expected_hostname: str, expected_path: str
 ) -> None:
     """Test that SSH-style URLs are correctly parsed."""
+    # Ensure detection is enabled
+    enable_ssh_style_url_detection()
+
     git_url = GitURL(url)
     assert git_url.user == expected_user
     assert git_url.hostname == expected_hostname


### PR DESCRIPTION
Fixes #49 

**In main repo URLs:**

Main repo URLs require `libvcs.url.git.GitURL` support:

Scheme: `user@domain.tld:org/repo.git`
Example: `git@github.com:tmux-python/tmuxp.git`

For remote URLs, see #419 

Note: The workaround is to prepend `git+ssh://git@github.com:tmux-python/tmuxp.git`