### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,16 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from vcspull import _internal, cli, config, exc, log, types, util, validator, __version__
+          from vcspull._internal import config_reader
+          from vcspull.cli import sync
+          print("vcspull version:", __version__)
+          print("libvcs version:", __libvcs_version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## See also

- https://github.com/vcs-python/libvcs/pull/486

## Summary by Sourcery

Adds a CI job to verify runtime dependencies before installing dev dependencies, ensuring the package functions correctly with its declared runtime dependencies.

CI:
- Adds a CI job to verify runtime dependencies using `uv run --no-dev` before installing dev dependencies.

Tests:
- Adds a runtime dependency check that prints the package version and runs basic functionality tests.