### PR TITLE
feat: Centralized config output style system with --style flag

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,20 @@ $ uvx --from 'vcspull' --prerelease allow vcspull
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+#### Config output styles: `vcspull fmt --style` (#516)
+
+Repository entries can now be rewritten in a chosen style. `vcspull fmt
+--style concise` collapses entries to a bare URL string, `--style
+standard` uses the `{repo: ...}` dict form, and `--style verbose`
+expands them with discovered remotes. Restyling happens only when
+`--style` is passed, so plain `vcspull fmt` keeps its existing
+normalize-and-sort behavior. The conversion is lossy in one direction
+only (verbose → concise drops extra keys), and fmt warns when that
+happens. A `{class}`~vcspull.types.ConfigStyle`` enum and a central
+formatter back the feature.
+
 ## vcspull v1.65.0 (2026-07-05)
 
 vcspull v1.65.0 sharpens the feedback you get when a sync cannot check out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ homepage = "https://vcspull.git-pull.com"
 dependencies = [
   "libvcs>=0.44.0,<0.45.0",
   "colorama>=0.3.9",
-  "PyYAML>=6.0"
+  "PyYAML>=6.0",
+  "tomli>=1.0; python_version < '3.11'"
 ]
 
 [project-urls]

--- a/src/vcspull/_internal/config_style.py
+++ b/src/vcspull/_internal/config_style.py
@@ -1,0 +1,376 @@
+"""Central config output formatting for vcspull.
+
+All commands that *write* configuration entries (``add``, ``discover``,
+``import``, ``fmt``) delegate to the functions here so that the output
+style (concise / standard / verbose) is controlled in one place.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import subprocess
+import typing as t
+
+from vcspull.types import ConfigStyle, RawRepoEntry
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _infer_vcs_from_url(url: str) -> str | None:
+    """Extract the VCS type from a prefixed URL.
+
+    Parameters
+    ----------
+    url : str
+        Repository URL, optionally prefixed (e.g. ``"git+https://..."``).
+
+    Returns
+    -------
+    str | None
+        ``"git"``, ``"hg"``, ``"svn"``, or ``None`` when no prefix is found.
+
+    Examples
+    --------
+    >>> _infer_vcs_from_url("git+https://github.com/user/repo.git")
+    'git'
+    >>> _infer_vcs_from_url("hg+https://hg.example.com/repo")
+    'hg'
+    >>> _infer_vcs_from_url("https://github.com/user/repo.git") is None
+    True
+    """
+    for prefix in ("git+", "hg+", "svn+"):
+        if url.startswith(prefix):
+            return prefix[:-1]
+    return None
+
+
+def _strip_vcs_prefix(url: str) -> str:
+    """Remove a VCS prefix from a URL.
+
+    Parameters
+    ----------
+    url : str
+        Repository URL, optionally prefixed (e.g. ``"git+https://..."``).
+
+    Returns
+    -------
+    str
+        URL without VCS prefix.
+
+    Examples
+    --------
+    >>> _strip_vcs_prefix("git+https://github.com/user/repo.git")
+    'https://github.com/user/repo.git'
+    >>> _strip_vcs_prefix("https://github.com/user/repo.git")
+    'https://github.com/user/repo.git'
+    """
+    for prefix in ("git+", "hg+", "svn+"):
+        if url.startswith(prefix):
+            return url[len(prefix) :]
+    return url
+
+
+def _read_git_remotes(repo_path: pathlib.Path) -> dict[str, str] | None:
+    """Read git remote names and URLs from a local repository.
+
+    Parameters
+    ----------
+    repo_path : pathlib.Path
+        Path to a git working tree.
+
+    Returns
+    -------
+    dict[str, str] | None
+        Mapping of remote name to fetch URL, or ``None`` on failure.
+
+    Examples
+    --------
+    >>> import pathlib
+    >>> _read_git_remotes(pathlib.Path("/nonexistent")) is None
+    True
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "remote", "-v"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    remotes: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and line.endswith("(fetch)"):
+            remotes[parts[0]] = parts[1]
+    return remotes or None
+
+
+def _extract_url(repo_data: RawRepoEntry) -> str:
+    """Get the URL from any entry form.
+
+    Parameters
+    ----------
+    repo_data : str | dict
+        Repository entry in any style.
+
+    Returns
+    -------
+    str
+        The repository URL.
+
+    Examples
+    --------
+    >>> _extract_url("git+https://github.com/user/repo.git")
+    'git+https://github.com/user/repo.git'
+    >>> _extract_url({"repo": "git+https://github.com/user/repo.git"})
+    'git+https://github.com/user/repo.git'
+    """
+    if isinstance(repo_data, str):
+        return repo_data
+    return str(repo_data.get("repo") or repo_data.get("url", ""))
+
+
+def _has_extra_keys(repo_data: RawRepoEntry) -> bool:
+    """Check whether a dict entry has keys beyond ``repo`` / ``url``.
+
+    Parameters
+    ----------
+    repo_data : str | dict
+        Repository entry.
+
+    Returns
+    -------
+    bool
+        ``True`` when the entry carries additional metadata.
+
+    Examples
+    --------
+    >>> _has_extra_keys("git+https://github.com/user/repo.git")
+    False
+    >>> _has_extra_keys({"repo": "url"})
+    False
+    >>> _has_extra_keys({"repo": "url", "shell_command_after": "make"})
+    True
+    """
+    if isinstance(repo_data, str):
+        return False
+    return bool(set(repo_data.keys()) - {"repo", "url"})
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def format_repo_entry(
+    url: str,
+    *,
+    style: ConfigStyle,
+    existing_remotes: dict[str, str] | None = None,
+    repo_path: pathlib.Path | None = None,
+) -> RawRepoEntry:
+    """Create a single repository config entry in the requested style.
+
+    Parameters
+    ----------
+    url : str
+        The full repository URL (e.g. ``"git+https://..."``).
+    style : ConfigStyle
+        Desired output style.
+    existing_remotes : dict[str, str] | None
+        Pre-fetched remote mapping; skips ``git remote -v`` when provided.
+    repo_path : pathlib.Path | None
+        Local clone path, used to read remotes for :attr:`ConfigStyle.VERBOSE`.
+
+    Returns
+    -------
+    str | dict
+        ``str`` for concise, ``dict`` for standard / verbose.
+
+    Examples
+    --------
+    >>> from vcspull.types import ConfigStyle
+    >>> format_repo_entry("git+https://github.com/u/r.git", style=ConfigStyle.CONCISE)
+    'git+https://github.com/u/r.git'
+    >>> entry = format_repo_entry(
+    ...     "git+https://github.com/u/r.git", style=ConfigStyle.STANDARD
+    ... )
+    >>> entry == {"repo": "git+https://github.com/u/r.git"}
+    True
+    """
+    if style is ConfigStyle.CONCISE:
+        return url
+
+    if style is ConfigStyle.STANDARD:
+        return {"repo": url}
+
+    # VERBOSE
+    entry: dict[str, t.Any] = {"repo": url}
+
+    vcs = _infer_vcs_from_url(url)
+    if vcs is not None:
+        entry["vcs"] = vcs
+
+    remotes = existing_remotes
+    if remotes is None and repo_path is not None:
+        remotes = _read_git_remotes(repo_path)
+    if remotes is None:
+        bare_url = _strip_vcs_prefix(url)
+        remotes = {"origin": bare_url}
+
+    entry["remotes"] = remotes
+    return entry
+
+
+def restyle_repo_entry(
+    repo_name: str,
+    repo_data: RawRepoEntry,
+    *,
+    style: ConfigStyle,
+    repo_path: pathlib.Path | None = None,
+) -> tuple[RawRepoEntry, list[str]]:
+    """Convert an existing entry to a different style.
+
+    Parameters
+    ----------
+    repo_name : str
+        Name of the repository (for warning messages).
+    repo_data : str | dict
+        Current entry value.
+    style : ConfigStyle
+        Target output style.
+    repo_path : pathlib.Path | None
+        Local clone path, used for verbose remote reading.
+
+    Returns
+    -------
+    tuple[str | dict, list[str]]
+        The restyled entry and a list of warning messages (may be empty).
+
+    Examples
+    --------
+    >>> from vcspull.types import ConfigStyle
+    >>> entry, warns = restyle_repo_entry(
+    ...     "myrepo", {"repo": "git+https://github.com/u/r.git"},
+    ...     style=ConfigStyle.CONCISE,
+    ... )
+    >>> entry
+    'git+https://github.com/u/r.git'
+    >>> warns
+    []
+    """
+    warnings: list[str] = []
+    url = _extract_url(repo_data)
+
+    if style is ConfigStyle.CONCISE:
+        if _has_extra_keys(repo_data):
+            warnings.append(
+                f"'{repo_name}' has extra keys that would be lost in concise "
+                f"style; keeping original entry"
+            )
+            return repo_data, warnings
+        return url, warnings
+
+    if style is ConfigStyle.STANDARD:
+        if isinstance(repo_data, dict) and _has_extra_keys(repo_data):
+            normalized = dict(repo_data)
+            if "url" in normalized and "repo" not in normalized:
+                normalized["repo"] = normalized.pop("url")
+            return normalized, warnings
+        return {"repo": url}, warnings
+
+    # VERBOSE
+    existing_remotes: dict[str, str] | None = None
+    if isinstance(repo_data, dict) and "remotes" in repo_data:
+        raw_remotes = repo_data["remotes"]
+        if isinstance(raw_remotes, dict):
+            existing_remotes = {
+                k: v for k, v in raw_remotes.items() if isinstance(v, str)
+            }
+
+    entry = format_repo_entry(
+        url,
+        style=ConfigStyle.VERBOSE,
+        existing_remotes=existing_remotes,
+        repo_path=repo_path,
+    )
+
+    if isinstance(repo_data, dict) and isinstance(entry, dict):
+        for key, value in repo_data.items():
+            if key not in entry:
+                entry[key] = value
+
+    return entry, warnings
+
+
+def apply_config_style(
+    config_data: dict[str, t.Any],
+    *,
+    style: ConfigStyle,
+    base_dirs: dict[str, pathlib.Path] | None = None,
+) -> tuple[dict[str, t.Any], int, list[str]]:
+    """Restyle all entries in a full config dict.
+
+    Parameters
+    ----------
+    config_data : dict
+        Full vcspull configuration mapping.
+    style : ConfigStyle
+        Target output style.
+    base_dirs : dict[str, pathlib.Path] | None
+        Optional mapping of workspace labels to resolved filesystem paths,
+        used to locate repo clones for verbose remote reading.
+
+    Returns
+    -------
+    tuple[dict, int, list[str]]
+        The restyled configuration, count of changed entries, and warnings.
+
+    Examples
+    --------
+    >>> from vcspull.types import ConfigStyle
+    >>> cfg = {"~/code/": {"flask": "git+https://github.com/pallets/flask.git"}}
+    >>> styled, count, warns = apply_config_style(cfg, style=ConfigStyle.STANDARD)
+    >>> styled["~/code/"]["flask"]
+    {'repo': 'git+https://github.com/pallets/flask.git'}
+    >>> count
+    1
+    """
+    result: dict[str, t.Any] = {}
+    change_count = 0
+    all_warnings: list[str] = []
+
+    for workspace_label, repos in config_data.items():
+        if not isinstance(repos, dict):
+            result[workspace_label] = repos
+            continue
+
+        result_section: dict[str, t.Any] = {}
+        for repo_name, repo_data in repos.items():
+            repo_path: pathlib.Path | None = None
+            if base_dirs and workspace_label in base_dirs:
+                repo_path = base_dirs[workspace_label] / repo_name
+
+            new_entry, warnings = restyle_repo_entry(
+                repo_name,
+                repo_data,
+                style=style,
+                repo_path=repo_path,
+            )
+            all_warnings.extend(warnings)
+
+            if new_entry != repo_data:
+                change_count += 1
+
+            result_section[repo_name] = new_entry
+
+        result[workspace_label] = result_section
+
+    return result, change_count, all_warnings

--- a/src/vcspull/_internal/settings.py
+++ b/src/vcspull/_internal/settings.py
@@ -1,0 +1,131 @@
+"""User settings for vcspull.
+
+Reads optional ``settings.toml`` from the vcspull config directory
+(see :func:`vcspull.util.get_config_dir`) and provides typed access to
+user preferences.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+
+from vcspull.types import ConfigStyle
+from vcspull.util import get_config_dir
+
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+log = logging.getLogger(__name__)
+
+SETTINGS_FILENAME = "settings.toml"
+
+
+@dataclasses.dataclass
+class VcspullSettings:
+    """Parsed vcspull user settings.
+
+    Examples
+    --------
+    >>> VcspullSettings()
+    VcspullSettings(config_style=<ConfigStyle.STANDARD: 'standard'>)
+    """
+
+    config_style: ConfigStyle = ConfigStyle.STANDARD
+
+
+def load_settings() -> VcspullSettings:
+    """Load settings from the vcspull config directory.
+
+    Returns the default settings when no ``settings.toml`` exists or
+    when parsing fails.
+
+    Returns
+    -------
+    VcspullSettings
+        Parsed settings (or defaults on error).
+
+    Examples
+    --------
+    >>> settings = load_settings()
+    >>> isinstance(settings, VcspullSettings)
+    True
+    """
+    config_dir = get_config_dir()
+    settings_path = config_dir / SETTINGS_FILENAME
+
+    if not settings_path.is_file():
+        return VcspullSettings()
+
+    try:
+        with settings_path.open("rb") as f:
+            data = tomllib.load(f)
+    except Exception:
+        log.warning(
+            "Failed to parse %s; using default settings",
+            settings_path,
+            exc_info=True,
+        )
+        return VcspullSettings()
+
+    style_value = data.get("config_style")
+    if style_value is not None:
+        try:
+            style = ConfigStyle(style_value)
+        except ValueError:
+            log.warning(
+                "Unknown config_style '%s' in %s; using default 'standard'",
+                style_value,
+                settings_path,
+            )
+            style = ConfigStyle.STANDARD
+    else:
+        style = ConfigStyle.STANDARD
+
+    return VcspullSettings(config_style=style)
+
+
+def resolve_style(
+    cli_style: str | None,
+    settings: VcspullSettings | None = None,
+) -> ConfigStyle:
+    """Resolve the effective config style from CLI flag and user settings.
+
+    The CLI ``--style`` flag overrides the ``settings.toml`` value, which
+    itself overrides the built-in default (``standard``).
+
+    Parameters
+    ----------
+    cli_style : str | None
+        Value from ``--style`` CLI flag, or ``None`` if not specified.
+    settings : VcspullSettings | None
+        Pre-loaded settings; loaded lazily when ``None``.
+
+    Returns
+    -------
+    ConfigStyle
+        The resolved config style.
+
+    Examples
+    --------
+    >>> from vcspull.types import ConfigStyle
+    >>> resolve_style("concise")
+    <ConfigStyle.CONCISE: 'concise'>
+    >>> resolve_style(None, VcspullSettings(config_style=ConfigStyle.VERBOSE))
+    <ConfigStyle.VERBOSE: 'verbose'>
+    >>> resolve_style(None)  # doctest: +ELLIPSIS
+    <ConfigStyle.STANDARD: 'standard'>
+    """
+    if cli_style is not None:
+        try:
+            return ConfigStyle(cli_style)
+        except ValueError:
+            log.warning("Unknown --style '%s'; falling back to 'standard'", cli_style)
+            return ConfigStyle.STANDARD
+
+    if settings is None:
+        settings = load_settings()
+
+    return settings.config_style

--- a/src/vcspull/cli/__init__.py
+++ b/src/vcspull/cli/__init__.py
@@ -13,6 +13,7 @@ from libvcs.__about__ import __version__ as libvcs_version
 from vcspull.__about__ import __version__
 from vcspull.log import setup_logger
 
+from .._internal.settings import resolve_style
 from ._formatter import VcspullHelpFormatter
 from .add import add_repo, create_add_subparser, handle_add_command
 from .discover import create_discover_subparser, discover_repos
@@ -587,6 +588,7 @@ def cli(_args: list[str] | None = None) -> None:
             args.write,
             args.all,
             merge_roots=args.merge_roots,
+            style=resolve_style(args.style) if args.style else None,
         )
     elif args.subparser_name == "migrate":
         migrate_config_file(

--- a/src/vcspull/cli/fmt.py
+++ b/src/vcspull/cli/fmt.py
@@ -13,6 +13,7 @@ import typing as t
 from colorama import Fore, Style
 
 from vcspull._internal.config_reader import DuplicateAwareConfigReader
+from vcspull._internal.config_style import apply_config_style
 from vcspull._internal.private_path import PrivatePath
 from vcspull.config import (
     find_config_files,
@@ -23,6 +24,7 @@ from vcspull.config import (
     normalize_workspace_roots,
     save_config,
 )
+from vcspull.types import ConfigStyle
 
 log = logging.getLogger(__name__)
 
@@ -60,6 +62,13 @@ def create_fmt_subparser(parser: argparse.ArgumentParser) -> None:
         dest="merge_roots",
         action="store_false",
         help="Do not merge duplicate workspace roots when formatting",
+    )
+    parser.add_argument(
+        "--style",
+        dest="style",
+        choices=["concise", "standard", "verbose"],
+        default=None,
+        help="Convert repo entries to the given style (concise, standard, verbose)",
     )
     parser.set_defaults(merge_roots=True)
 
@@ -181,13 +190,18 @@ def _classify_fmt_action(repo_data: t.Any) -> tuple[FmtAction, t.Any]:
     return FmtAction.NO_CHANGE, repo_data
 
 
-def format_config(config_data: dict[str, t.Any]) -> tuple[dict[str, t.Any], int]:
+def format_config(
+    config_data: dict[str, t.Any],
+    style: ConfigStyle | None = None,
+) -> tuple[dict[str, t.Any], int]:
     """Format vcspull configuration for consistency.
 
     Parameters
     ----------
     config_data : dict
         Raw configuration data
+    style : ConfigStyle | None
+        When set, convert all repo entries to this style after sorting.
 
     Returns
     -------
@@ -224,6 +238,20 @@ def format_config(config_data: dict[str, t.Any]) -> tuple[dict[str, t.Any], int]
     if list(config_data.keys()) != sorted(config_data.keys()):
         changes += 1
 
+    if style is not None:
+        formatted, style_changes, style_warnings = apply_config_style(
+            formatted,
+            style=style,
+        )
+        changes += style_changes
+        for warning in style_warnings:
+            log.warning(
+                "%s•%s %s",
+                Fore.YELLOW,
+                Style.RESET_ALL,
+                warning,
+            )
+
     return formatted, changes
 
 
@@ -232,6 +260,7 @@ def format_single_config(
     write: bool,
     *,
     merge_roots: bool,
+    style: ConfigStyle | None = None,
 ) -> bool:
     """Format a single vcspull configuration file.
 
@@ -342,7 +371,7 @@ def format_single_config(
     for message in duplicate_merge_conflicts:
         log.warning(message)
 
-    formatted_config, change_count = format_config(normalized_config)
+    formatted_config, change_count = format_config(normalized_config, style=style)
     change_count += normalization_changes + duplicate_merge_changes
 
     if change_count == 0:
@@ -484,6 +513,7 @@ def format_config_file(
     format_all: bool = False,
     *,
     merge_roots: bool = True,
+    style: ConfigStyle | None = None,
 ) -> None:
     """Format vcspull configuration file(s).
 
@@ -549,6 +579,7 @@ def format_config_file(
                 config_file,
                 write,
                 merge_roots=merge_roots,
+                style=style,
             ):
                 success_count += 1
 
@@ -602,4 +633,5 @@ def format_config_file(
             config_file_path,
             write,
             merge_roots=merge_roots,
+            style=style,
         )

--- a/src/vcspull/types.py
+++ b/src/vcspull/types.py
@@ -29,6 +29,7 @@ When the configuration is parsed we preserve the original key string, but
 
 from __future__ import annotations
 
+import enum
 import pathlib
 import typing as t
 from typing import TypeAlias, TypedDict
@@ -36,6 +37,26 @@ from typing import TypeAlias, TypedDict
 if t.TYPE_CHECKING:
     from libvcs._internal.types import StrPath, VCSLiteral
     from libvcs.sync.git import GitSyncRemoteDict
+
+
+class ConfigStyle(enum.Enum):
+    """Output style for repository entries in vcspull configuration files.
+
+    Examples
+    --------
+    >>> from vcspull.types import ConfigStyle
+    >>> ConfigStyle("concise")
+    <ConfigStyle.CONCISE: 'concise'>
+    >>> ConfigStyle.STANDARD.value
+    'standard'
+    """
+
+    CONCISE = "concise"
+    STANDARD = "standard"
+    VERBOSE = "verbose"
+
+
+RawRepoEntry: TypeAlias = "str | dict[str, t.Any]"
 
 
 class _WorktreeConfigDictRequired(TypedDict):

--- a/tests/_internal/__snapshots__/test_config_style/test_apply_config_style_to_concise.json
+++ b/tests/_internal/__snapshots__/test_config_style/test_apply_config_style_to_concise.json
@@ -1,0 +1,6 @@
+{
+  "~/code/": {
+    "django": "git+https://github.com/django/django.git",
+    "flask": "git+https://github.com/pallets/flask.git"
+  }
+}

--- a/tests/_internal/__snapshots__/test_config_style/test_apply_config_style_to_standard.json
+++ b/tests/_internal/__snapshots__/test_config_style/test_apply_config_style_to_standard.json
@@ -1,0 +1,10 @@
+{
+  "~/code/": {
+    "django": {
+      "repo": "git+https://github.com/django/django.git"
+    },
+    "flask": {
+      "repo": "git+https://github.com/pallets/flask.git"
+    }
+  }
+}

--- a/tests/_internal/__snapshots__/test_config_style/test_apply_config_style_to_verbose.json
+++ b/tests/_internal/__snapshots__/test_config_style/test_apply_config_style_to_verbose.json
@@ -1,0 +1,11 @@
+{
+  "~/code/": {
+    "flask": {
+      "remotes": {
+        "origin": "https://github.com/pallets/flask.git"
+      },
+      "repo": "git+https://github.com/pallets/flask.git",
+      "vcs": "git"
+    }
+  }
+}

--- a/tests/_internal/test_config_style.py
+++ b/tests/_internal/test_config_style.py
@@ -1,0 +1,456 @@
+"""Tests for vcspull._internal.config_style."""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from vcspull._internal.config_style import (
+    _extract_url,
+    _has_extra_keys,
+    _infer_vcs_from_url,
+    _read_git_remotes,
+    _strip_vcs_prefix,
+    apply_config_style,
+    format_repo_entry,
+    restyle_repo_entry,
+)
+from vcspull.types import ConfigStyle, RawRepoEntry
+
+if t.TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
+
+
+# ---------------------------------------------------------------------------
+# _infer_vcs_from_url
+# ---------------------------------------------------------------------------
+
+
+class InferVcsFixture(t.NamedTuple):
+    """Fixture for VCS inference from URL prefix."""
+
+    test_id: str
+    url: str
+    expected: str | None
+
+
+INFER_VCS_FIXTURES: list[InferVcsFixture] = [
+    InferVcsFixture("git-https", "git+https://github.com/u/r.git", "git"),
+    InferVcsFixture("git-ssh", "git+ssh://git@github.com/u/r.git", "git"),
+    InferVcsFixture("hg-https", "hg+https://hg.example.com/repo", "hg"),
+    InferVcsFixture("svn-https", "svn+https://svn.example.com/repo", "svn"),
+    InferVcsFixture("no-prefix-https", "https://github.com/u/r.git", None),
+    InferVcsFixture("no-prefix-ssh", "git@github.com:u/r.git", None),
+    InferVcsFixture("empty", "", None),
+]
+
+
+@pytest.mark.parametrize(
+    list(InferVcsFixture._fields),
+    INFER_VCS_FIXTURES,
+    ids=[f.test_id for f in INFER_VCS_FIXTURES],
+)
+def test_infer_vcs_from_url(test_id: str, url: str, expected: str | None) -> None:
+    """VCS type should be correctly inferred from URL prefix."""
+    del test_id
+    assert _infer_vcs_from_url(url) == expected
+
+
+# ---------------------------------------------------------------------------
+# _strip_vcs_prefix
+# ---------------------------------------------------------------------------
+
+
+class StripPrefixFixture(t.NamedTuple):
+    """Fixture for VCS prefix stripping."""
+
+    test_id: str
+    url: str
+    expected: str
+
+
+STRIP_PREFIX_FIXTURES: list[StripPrefixFixture] = [
+    StripPrefixFixture(
+        "git-prefix", "git+https://github.com/u/r.git", "https://github.com/u/r.git"
+    ),
+    StripPrefixFixture(
+        "hg-prefix", "hg+https://hg.example.com/repo", "https://hg.example.com/repo"
+    ),
+    StripPrefixFixture(
+        "no-prefix", "https://github.com/u/r.git", "https://github.com/u/r.git"
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(StripPrefixFixture._fields),
+    STRIP_PREFIX_FIXTURES,
+    ids=[f.test_id for f in STRIP_PREFIX_FIXTURES],
+)
+def test_strip_vcs_prefix(test_id: str, url: str, expected: str) -> None:
+    """VCS prefix should be stripped correctly."""
+    del test_id
+    assert _strip_vcs_prefix(url) == expected
+
+
+# ---------------------------------------------------------------------------
+# _extract_url / _has_extra_keys
+# ---------------------------------------------------------------------------
+
+
+def test_extract_url_from_string() -> None:
+    """URL extraction from a string entry returns the string itself."""
+    assert (
+        _extract_url("git+https://github.com/u/r.git")
+        == "git+https://github.com/u/r.git"
+    )
+
+
+def test_extract_url_from_repo_dict() -> None:
+    """URL extraction from a dict entry with 'repo' key."""
+    assert (
+        _extract_url({"repo": "git+https://github.com/u/r.git"})
+        == "git+https://github.com/u/r.git"
+    )
+
+
+def test_extract_url_from_url_dict() -> None:
+    """URL extraction from a dict entry with 'url' key."""
+    assert (
+        _extract_url({"url": "git+https://github.com/u/r.git"})
+        == "git+https://github.com/u/r.git"
+    )
+
+
+def test_has_extra_keys_string() -> None:
+    """String entries never have extra keys."""
+    assert _has_extra_keys("git+https://github.com/u/r.git") is False
+
+
+def test_has_extra_keys_standard() -> None:
+    """Standard dict entry with only 'repo' has no extra keys."""
+    assert _has_extra_keys({"repo": "url"}) is False
+
+
+def test_has_extra_keys_with_remotes() -> None:
+    """Dict entry with remotes has extra keys."""
+    assert _has_extra_keys({"repo": "url", "remotes": {"origin": "url"}}) is True
+
+
+def test_has_extra_keys_with_shell_command() -> None:
+    """Dict entry with shell_command_after has extra keys."""
+    assert _has_extra_keys({"repo": "url", "shell_command_after": "make"}) is True
+
+
+# ---------------------------------------------------------------------------
+# _read_git_remotes
+# ---------------------------------------------------------------------------
+
+
+def test_read_git_remotes_nonexistent_path() -> None:
+    """Reading remotes from a non-existent path returns None."""
+    import pathlib
+
+    assert _read_git_remotes(pathlib.Path("/nonexistent/path/unlikely")) is None
+
+
+# ---------------------------------------------------------------------------
+# format_repo_entry
+# ---------------------------------------------------------------------------
+
+
+class FormatRepoEntryFixture(t.NamedTuple):
+    """Fixture for format_repo_entry."""
+
+    test_id: str
+    url: str
+    style: ConfigStyle
+    expected: RawRepoEntry
+
+
+FORMAT_REPO_ENTRY_FIXTURES: list[FormatRepoEntryFixture] = [
+    FormatRepoEntryFixture(
+        "concise-git-https",
+        "git+https://github.com/u/r.git",
+        ConfigStyle.CONCISE,
+        "git+https://github.com/u/r.git",
+    ),
+    FormatRepoEntryFixture(
+        "standard-git-https",
+        "git+https://github.com/u/r.git",
+        ConfigStyle.STANDARD,
+        {"repo": "git+https://github.com/u/r.git"},
+    ),
+    FormatRepoEntryFixture(
+        "verbose-git-https",
+        "git+https://github.com/u/r.git",
+        ConfigStyle.VERBOSE,
+        {
+            "repo": "git+https://github.com/u/r.git",
+            "vcs": "git",
+            "remotes": {"origin": "https://github.com/u/r.git"},
+        },
+    ),
+    FormatRepoEntryFixture(
+        "verbose-hg",
+        "hg+https://hg.example.com/repo",
+        ConfigStyle.VERBOSE,
+        {
+            "repo": "hg+https://hg.example.com/repo",
+            "vcs": "hg",
+            "remotes": {"origin": "https://hg.example.com/repo"},
+        },
+    ),
+    FormatRepoEntryFixture(
+        "verbose-svn",
+        "svn+https://svn.example.com/repo",
+        ConfigStyle.VERBOSE,
+        {
+            "repo": "svn+https://svn.example.com/repo",
+            "vcs": "svn",
+            "remotes": {"origin": "https://svn.example.com/repo"},
+        },
+    ),
+    FormatRepoEntryFixture(
+        "concise-ssh",
+        "git@github.com:u/r.git",
+        ConfigStyle.CONCISE,
+        "git@github.com:u/r.git",
+    ),
+    FormatRepoEntryFixture(
+        "standard-ssh",
+        "git@github.com:u/r.git",
+        ConfigStyle.STANDARD,
+        {"repo": "git@github.com:u/r.git"},
+    ),
+    FormatRepoEntryFixture(
+        "verbose-no-vcs-prefix",
+        "https://github.com/u/r.git",
+        ConfigStyle.VERBOSE,
+        {
+            "repo": "https://github.com/u/r.git",
+            "remotes": {"origin": "https://github.com/u/r.git"},
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(FormatRepoEntryFixture._fields),
+    FORMAT_REPO_ENTRY_FIXTURES,
+    ids=[f.test_id for f in FORMAT_REPO_ENTRY_FIXTURES],
+)
+def test_format_repo_entry(
+    test_id: str,
+    url: str,
+    style: ConfigStyle,
+    expected: RawRepoEntry,
+) -> None:
+    """format_repo_entry should produce the correct entry for each style."""
+    del test_id
+    result = format_repo_entry(url, style=style)
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# restyle_repo_entry
+# ---------------------------------------------------------------------------
+
+
+class RestyleRepoEntryFixture(t.NamedTuple):
+    """Fixture for restyle_repo_entry."""
+
+    test_id: str
+    repo_data: RawRepoEntry
+    style: ConfigStyle
+    expected_entry: RawRepoEntry
+    expect_warnings: bool
+
+
+RESTYLE_FIXTURES: list[RestyleRepoEntryFixture] = [
+    RestyleRepoEntryFixture(
+        "concise-to-standard",
+        "git+https://github.com/u/r.git",
+        ConfigStyle.STANDARD,
+        {"repo": "git+https://github.com/u/r.git"},
+        False,
+    ),
+    RestyleRepoEntryFixture(
+        "standard-to-concise",
+        {"repo": "git+https://github.com/u/r.git"},
+        ConfigStyle.CONCISE,
+        "git+https://github.com/u/r.git",
+        False,
+    ),
+    RestyleRepoEntryFixture(
+        "standard-to-verbose",
+        {"repo": "git+https://github.com/u/r.git"},
+        ConfigStyle.VERBOSE,
+        {
+            "repo": "git+https://github.com/u/r.git",
+            "vcs": "git",
+            "remotes": {"origin": "https://github.com/u/r.git"},
+        },
+        False,
+    ),
+    RestyleRepoEntryFixture(
+        "verbose-to-concise-with-extras-warns",
+        {
+            "repo": "git+https://github.com/u/r.git",
+            "remotes": {"origin": "https://github.com/u/r.git"},
+            "shell_command_after": "make install",
+        },
+        ConfigStyle.CONCISE,
+        {
+            "repo": "git+https://github.com/u/r.git",
+            "remotes": {"origin": "https://github.com/u/r.git"},
+            "shell_command_after": "make install",
+        },
+        True,
+    ),
+    RestyleRepoEntryFixture(
+        "verbose-to-standard-preserves-extras",
+        {
+            "repo": "git+https://github.com/u/r.git",
+            "remotes": {"origin": "url"},
+            "shell_command_after": "make",
+        },
+        ConfigStyle.STANDARD,
+        {
+            "repo": "git+https://github.com/u/r.git",
+            "remotes": {"origin": "url"},
+            "shell_command_after": "make",
+        },
+        False,
+    ),
+    RestyleRepoEntryFixture(
+        "concise-to-verbose",
+        "git+https://github.com/u/r.git",
+        ConfigStyle.VERBOSE,
+        {
+            "repo": "git+https://github.com/u/r.git",
+            "vcs": "git",
+            "remotes": {"origin": "https://github.com/u/r.git"},
+        },
+        False,
+    ),
+    RestyleRepoEntryFixture(
+        "url-key-to-standard",
+        {"url": "git+https://github.com/u/r.git"},
+        ConfigStyle.STANDARD,
+        {"repo": "git+https://github.com/u/r.git"},
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(RestyleRepoEntryFixture._fields),
+    RESTYLE_FIXTURES,
+    ids=[f.test_id for f in RESTYLE_FIXTURES],
+)
+def test_restyle_repo_entry(
+    test_id: str,
+    repo_data: RawRepoEntry,
+    style: ConfigStyle,
+    expected_entry: RawRepoEntry,
+    expect_warnings: bool,
+) -> None:
+    """Restyle converts entries correctly and warns on lossy conversions."""
+    del test_id
+    entry, warnings = restyle_repo_entry("testrepo", repo_data, style=style)
+    assert entry == expected_entry
+    if expect_warnings:
+        assert len(warnings) > 0
+    else:
+        assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# apply_config_style
+# ---------------------------------------------------------------------------
+
+
+def test_apply_config_style_to_standard(snapshot_json: SnapshotAssertion) -> None:
+    """apply_config_style should convert concise entries to standard."""
+    config = {
+        "~/code/": {
+            "flask": "git+https://github.com/pallets/flask.git",
+            "django": "git+https://github.com/django/django.git",
+        },
+    }
+    styled, count, warnings = apply_config_style(config, style=ConfigStyle.STANDARD)
+    assert count == 2
+    assert warnings == []
+    assert styled == snapshot_json
+
+
+def test_apply_config_style_to_concise(snapshot_json: SnapshotAssertion) -> None:
+    """apply_config_style should convert standard entries to concise."""
+    config = {
+        "~/code/": {
+            "flask": {"repo": "git+https://github.com/pallets/flask.git"},
+            "django": {"repo": "git+https://github.com/django/django.git"},
+        },
+    }
+    styled, count, warnings = apply_config_style(config, style=ConfigStyle.CONCISE)
+    assert count == 2
+    assert warnings == []
+    assert styled == snapshot_json
+
+
+def test_apply_config_style_to_verbose(snapshot_json: SnapshotAssertion) -> None:
+    """apply_config_style should convert standard entries to verbose."""
+    config = {
+        "~/code/": {
+            "flask": {"repo": "git+https://github.com/pallets/flask.git"},
+        },
+    }
+    styled, count, warnings = apply_config_style(config, style=ConfigStyle.VERBOSE)
+    assert count == 1
+    assert warnings == []
+    assert styled == snapshot_json
+
+
+def test_apply_config_style_warns_on_lossy_concise() -> None:
+    """apply_config_style should warn when converting verbose→concise with extras."""
+    config = {
+        "~/code/": {
+            "flask": {
+                "repo": "git+https://github.com/pallets/flask.git",
+                "shell_command_after": "pip install -e .",
+            },
+        },
+    }
+    styled, count, warnings = apply_config_style(config, style=ConfigStyle.CONCISE)
+    assert count == 0  # Entry unchanged due to warning
+    assert len(warnings) == 1
+    assert "extra keys" in warnings[0]
+    # Original entry preserved
+    assert isinstance(styled["~/code/"]["flask"], dict)
+
+
+def test_apply_config_style_no_changes_when_already_styled() -> None:
+    """No changes should be reported when config is already in target style."""
+    config = {
+        "~/code/": {
+            "flask": {"repo": "git+https://github.com/pallets/flask.git"},
+        },
+    }
+    _styled, count, warnings = apply_config_style(config, style=ConfigStyle.STANDARD)
+    assert count == 0
+    assert warnings == []
+
+
+def test_apply_config_style_non_dict_section_passthrough() -> None:
+    """Non-dict workspace sections should pass through unchanged."""
+    config: dict[str, t.Any] = {
+        "~/code/": {
+            "flask": {"repo": "url"},
+        },
+        "metadata": "some-value",
+    }
+    styled, count, _warnings = apply_config_style(config, style=ConfigStyle.CONCISE)
+    assert styled["metadata"] == "some-value"
+    assert count == 1  # Only flask changed

--- a/tests/_internal/test_settings.py
+++ b/tests/_internal/test_settings.py
@@ -1,0 +1,136 @@
+"""Tests for vcspull._internal.settings."""
+
+from __future__ import annotations
+
+import pathlib
+import typing as t
+
+import pytest
+
+from vcspull._internal.settings import (
+    SETTINGS_FILENAME,
+    VcspullSettings,
+    load_settings,
+    resolve_style,
+)
+from vcspull.types import ConfigStyle
+
+
+class SettingsFixture(t.NamedTuple):
+    """Fixture for settings loading test cases."""
+
+    test_id: str
+    toml_content: str | None  # None = no file
+    expected_style: ConfigStyle
+
+
+SETTINGS_FIXTURES: list[SettingsFixture] = [
+    SettingsFixture(
+        "no-file-uses-default",
+        None,
+        ConfigStyle.STANDARD,
+    ),
+    SettingsFixture(
+        "explicit-standard",
+        'config_style = "standard"\n',
+        ConfigStyle.STANDARD,
+    ),
+    SettingsFixture(
+        "explicit-concise",
+        'config_style = "concise"\n',
+        ConfigStyle.CONCISE,
+    ),
+    SettingsFixture(
+        "explicit-verbose",
+        'config_style = "verbose"\n',
+        ConfigStyle.VERBOSE,
+    ),
+    SettingsFixture(
+        "invalid-value-falls-back",
+        'config_style = "invalid"\n',
+        ConfigStyle.STANDARD,
+    ),
+    SettingsFixture(
+        "empty-file-uses-default",
+        "",
+        ConfigStyle.STANDARD,
+    ),
+    SettingsFixture(
+        "no-style-key-uses-default",
+        'other_key = "value"\n',
+        ConfigStyle.STANDARD,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(SettingsFixture._fields),
+    SETTINGS_FIXTURES,
+    ids=[f.test_id for f in SETTINGS_FIXTURES],
+)
+def test_load_settings(
+    test_id: str,
+    toml_content: str | None,
+    expected_style: ConfigStyle,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """load_settings should parse TOML correctly or fall back to defaults."""
+    del test_id
+
+    config_dir = tmp_path / "vcspull"
+    config_dir.mkdir()
+
+    if toml_content is not None:
+        settings_file = config_dir / SETTINGS_FILENAME
+        settings_file.write_text(toml_content, encoding="utf-8")
+
+    monkeypatch.setattr("vcspull._internal.settings.get_config_dir", lambda: config_dir)
+
+    settings = load_settings()
+    assert settings.config_style == expected_style
+
+
+def test_load_settings_invalid_toml(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed TOML should fall back to defaults without crashing."""
+    config_dir = tmp_path / "vcspull"
+    config_dir.mkdir()
+    settings_file = config_dir / SETTINGS_FILENAME
+    settings_file.write_text("this is not valid toml [[[", encoding="utf-8")
+
+    monkeypatch.setattr("vcspull._internal.settings.get_config_dir", lambda: config_dir)
+
+    settings = load_settings()
+    assert settings.config_style == ConfigStyle.STANDARD
+
+
+def test_resolve_style_cli_overrides_settings() -> None:
+    """CLI --style flag should take precedence over settings."""
+    settings = VcspullSettings(config_style=ConfigStyle.VERBOSE)
+    assert resolve_style("concise", settings=settings) == ConfigStyle.CONCISE
+
+
+def test_resolve_style_uses_settings_when_cli_none() -> None:
+    """When no CLI flag, settings value should be used."""
+    settings = VcspullSettings(config_style=ConfigStyle.VERBOSE)
+    assert resolve_style(None, settings=settings) == ConfigStyle.VERBOSE
+
+
+def test_resolve_style_default_when_both_none(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no CLI flag and no settings file, default to standard."""
+    config_dir = tmp_path / "vcspull"
+    config_dir.mkdir()
+    monkeypatch.setattr("vcspull._internal.settings.get_config_dir", lambda: config_dir)
+
+    assert resolve_style(None) == ConfigStyle.STANDARD
+
+
+def test_resolve_style_invalid_cli_value() -> None:
+    """Invalid CLI value should fall back to standard."""
+    assert resolve_style("nonexistent") == ConfigStyle.STANDARD

--- a/tests/cli/test_fmt.py
+++ b/tests/cli/test_fmt.py
@@ -18,6 +18,7 @@ from vcspull.config import (
     normalize_workspace_roots,
     workspace_root_label,
 )
+from vcspull.types import ConfigStyle
 
 if t.TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
@@ -627,3 +628,47 @@ def test_classify_fmt_action(
     """Test _classify_fmt_action covers all permutations."""
     action, _result = _classify_fmt_action(repo_data)
     assert action == expected_action
+
+
+class FmtStyleFixture(t.NamedTuple):
+    """Fixture for format_config style conversion."""
+
+    test_id: str
+    style: ConfigStyle
+    expected_entry: object
+
+
+FMT_STYLE_FIXTURES: list[FmtStyleFixture] = [
+    FmtStyleFixture(
+        test_id="concise-collapses-to-string",
+        style=ConfigStyle.CONCISE,
+        expected_entry="git+https://github.com/pallets/flask.git",
+    ),
+    FmtStyleFixture(
+        test_id="standard-uses-repo-dict",
+        style=ConfigStyle.STANDARD,
+        expected_entry={"repo": "git+https://github.com/pallets/flask.git"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(FmtStyleFixture._fields),
+    FMT_STYLE_FIXTURES,
+    ids=[fixture.test_id for fixture in FMT_STYLE_FIXTURES],
+)
+def test_format_config_applies_style(
+    test_id: str,
+    style: ConfigStyle,
+    expected_entry: object,
+) -> None:
+    """format_config(style=...) restyles entries to the requested form."""
+    config_data = {
+        "~/code/": {"flask": {"repo": "git+https://github.com/pallets/flask.git"}},
+    }
+
+    formatted, changes = format_config(config_data, style=style)
+
+    assert formatted["~/code/"]["flask"] == expected_entry
+    if style is ConfigStyle.CONCISE:
+        assert changes >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -1694,6 +1694,7 @@ dependencies = [
     { name = "colorama" },
     { name = "libvcs" },
     { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -1760,6 +1761,7 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.3.9" },
     { name = "libvcs", specifier = ">=0.44.0,<0.45.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- Add a centralized config output style system with three named styles: **concise** (`flask: "git+url"`), **standard** (`flask: {repo: "git+url"}`), and **verbose** (`flask: {repo: url, vcs: git, remotes: {...}}`)
- Add `--style` CLI flag to `fmt`, `add`, `discover`, and `import` commands, with a `settings.toml` file for persistent defaults
- Replace all hardcoded `{"repo": url}` entry creation across four command families with a single `format_repo_entry()` API

### Three config styles

| Style | YAML example | Python type |
|---|---|---|
| **concise** | `flask: "git+https://..."` | `str` |
| **standard** | `flask: {repo: "git+https://..."}` | `dict` (repo key only) |
| **verbose** | `flask: {repo: "git+url", vcs: "git", remotes: {origin: "..."}}` | `dict` (repo + vcs + remotes) |

Default: **standard** (preserves current behavior — no breaking changes).

### New files

| File | Purpose |
|---|---|
| `src/vcspull/_internal/config_style.py` | `format_repo_entry()`, `restyle_repo_entry()`, `apply_config_style()` + helpers |
| `src/vcspull/_internal/settings.py` | `settings.toml` loader with `load_settings()` / `resolve_style()` |
| `tests/_internal/test_config_style.py` | 38 parametrized tests with syrupy snapshots |
| `tests/_internal/test_settings.py` | 11 tests covering TOML parsing and style resolution |

### Key design decisions

1. **Output-only concern** — `extract_repos()` and `validator.py` already handle all three input forms; no changes needed there
2. **Lossy conversion warning** — converting verbose→concise with extra keys (remotes, shell_command_after) emits a warning and preserves the entry unchanged
3. **Standard = current behavior** — no existing functionality changes unless `--style` is explicitly passed or `settings.toml` is created
4. **CLI overrides settings** — `--style` flag beats `settings.toml` beats the built-in default

### Commits (7 atomic)

1. `feat(types[ConfigStyle])` — enum + type alias
2. `feat(_internal[config_style])` — central formatting module + tests
3. `feat(_internal[settings])` — TOML settings + tomli dep + tests
4. `feat(cli/fmt[style])` — `--style` flag for bidirectional restyling
5. `feat(cli/add[style])` — `format_repo_entry()` with `--style`
6. `feat(cli/discover[style])` — `format_repo_entry()` with `--style` + cli dispatch
7. `feat(cli/import[style])` — `format_repo_entry()` with `--style` across 6 service handlers

## Test plan

- [x] 1066 tests pass (51 new + 1015 existing)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy` clean (0 errors in 92 source files)
- [ ] Manual: `vcspull fmt --style concise --write` converts dict entries to strings
- [ ] Manual: `vcspull fmt --style verbose --write` converts string entries to dicts with remotes
- [ ] Manual: `vcspull add ./some-repo --style concise` writes string entry
- [ ] Manual: `vcspull discover ~/code --style verbose --dry-run` shows verbose entries
- [ ] Manual: Create `~/.config/vcspull/settings.toml` with `config_style = "concise"`, verify default