### PR TITLE
fix(filter_repos): match full repo paths and normalize trailing slashes

### DIFF
--- a/src/vcspull/config.py
+++ b/src/vcspull/config.py
@@ -716,11 +716,17 @@ def filter_repos(
     repo_list: list[ConfigDict] = []
 
     if path:
+        path_str = str(path)
+        if "~" in path_str or "$" in path_str:
+            path_str = str(expand_dir(pathlib.Path(path_str)))
+        else:
+            path_str = str(pathlib.Path(path_str))
         repo_list.extend(
             [
                 r
                 for r in config
-                if fnmatch.fnmatch(str(pathlib.Path(r["path"]).parent), str(path))
+                if fnmatch.fnmatch(str(pathlib.Path(r["path"]).parent), path_str)
+                or fnmatch.fnmatch(str(r["path"]), path_str)
             ],
         )
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import typing as t
 
-import pytest
 from libvcs import BaseSync, GitSync, HgSync, SvnSync
 from libvcs._internal.shortcuts import create_project
 
@@ -25,9 +24,6 @@ def test_filter_dir() -> None:
         assert r["name"] == "kaptan"
 
 
-@pytest.mark.xfail(
-    reason="filter_repos matches parent dir only; full paths not matched"
-)
 def test_filter_dir_exact_repo_path() -> None:
     """`filter_repos` filter by exact full repo path (e.g. after zsh glob expansion)."""
     repo_list = filter_repos(
@@ -38,9 +34,6 @@ def test_filter_dir_exact_repo_path() -> None:
     assert repo_list[0]["name"] == "kaptan"
 
 
-@pytest.mark.xfail(
-    reason="filter_repos parent-dir fnmatch fails with trailing slash",
-)
 def test_filter_dir_workspace_root_trailing_slash() -> None:
     """`filter_repos` filter by workspace root path with trailing slash."""
     repo_list = filter_repos(

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typing as t
 
+import pytest
 from libvcs import BaseSync, GitSync, HgSync, SvnSync
 from libvcs._internal.shortcuts import create_project
 
@@ -22,6 +23,32 @@ def test_filter_dir() -> None:
     assert len(repo_list) == 1
     for r in repo_list:
         assert r["name"] == "kaptan"
+
+
+@pytest.mark.xfail(
+    reason="filter_repos matches parent dir only; full paths not matched"
+)
+def test_filter_dir_exact_repo_path() -> None:
+    """`filter_repos` filter by exact full repo path (e.g. after zsh glob expansion)."""
+    repo_list = filter_repos(
+        fixtures.config_dict_expanded,
+        path="/home/me/myproject/github_projects/kaptan",
+    )
+    assert len(repo_list) == 1
+    assert repo_list[0]["name"] == "kaptan"
+
+
+@pytest.mark.xfail(
+    reason="filter_repos parent-dir fnmatch fails with trailing slash",
+)
+def test_filter_dir_workspace_root_trailing_slash() -> None:
+    """`filter_repos` filter by workspace root path with trailing slash."""
+    repo_list = filter_repos(
+        fixtures.config_dict_expanded,
+        path="/home/me/myproject/github_projects/",
+    )
+    assert len(repo_list) == 1
+    assert repo_list[0]["name"] == "kaptan"
 
 
 def test_filter_name() -> None:


### PR DESCRIPTION
## Summary

- **Fix** `filter_repos()` so that passing a full repo path (e.g. `/home/d/study/typescript/tanstack-router`, as produced by shell glob expansion) correctly matches the configured repository — previously only the parent directory was matched against the pattern, so exact repo paths never resolved.
- **Fix** workspace-root patterns with a trailing slash (e.g. `~/study/typescript/`) silently returning no results due to the slash surviving into the `fnmatch` comparison against the normalized stored path.
- **Fix** tilde and `$HOME` patterns (e.g. `~/study/typescript/tanstack-router`) not matching stored absolute paths by expanding them via the existing `expand_dir()` before comparison.
- **Add** two regression tests for the new matching modes: filtering by exact full repo path, and filtering by workspace root with a trailing slash.

## Root cause

`filter_repos()` compared only `pathlib.Path(r["path"]).parent` against the pattern — designed for wildcard workspace patterns like `*github_projects*`. This broke when the shell expanded a glob such as `~/study/typescript/tanstack-*` into a list of absolute repo paths before handing them to vcspull: `discover` found those repos in config via dict-key lookup, but `sync` could not.

## Changes

**`src/vcspull/config.py`** — `filter_repos()` path block:
- Normalize the pattern through `pathlib.Path` to strip trailing slashes
- Expand `~` / `$HOME` via `expand_dir()` when present, so tilde patterns match stored absolute paths
- OR the existing parent-dir `fnmatch` with a new full-path `fnmatch`, making exact repo paths resolve without breaking any existing wildcard behavior

## Design decisions

**OR semantics, not replacement**: matching against both `r["path"].parent` (existing) and `r["path"]` (new) is strictly additive — it can only produce more matches. All existing wildcard tests continue to pass unchanged.

**Reuse `expand_dir()`**: already defined in the same module with `expandvars` + `expanduser` semantics; no duplication needed.

## Test plan

- [x] `test_filter_dir_exact_repo_path` — full absolute repo path resolves to the correct entry
- [x] `test_filter_dir_workspace_root_trailing_slash` — workspace root with trailing slash resolves all repos under it
- [x] `test_filter_dir` — existing wildcard pattern (`*github_project*`) still passes
- [x] `uv run ruff check . --fix --show-fixes` — no lint errors
- [x] `uv run ruff format .` — no formatting changes
- [x] `uv run mypy` — no type errors
- [x] `uv run py.test --reruns 0` — full suite passes