### PR TITLE
feat(sync[dry-run]): auto-show all matched repos when filtering explicitly

### DIFF
--- a/src/vcspull/cli/_output.py
+++ b/src/vcspull/cli/_output.py
@@ -154,6 +154,7 @@ class PlanRenderOptions:
     """Rendering options for human plan output."""
 
     show_unchanged: bool = False
+    has_explicit_patterns: bool = False
     summary_only: bool = False
     long: bool = False
     verbosity: int = 0

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -79,6 +79,7 @@ PLAN_ORDER: dict[PlanAction, int] = {
 PLAN_TIP_MESSAGE = (
     "Tip: run without --dry-run to apply. Use --show-unchanged to include ✓ rows."
 )
+PLAN_TIP_MESSAGE_FILTERED = "Tip: run without --dry-run to apply."
 
 DEFAULT_PLAN_CONCURRENCY = max(1, min(32, (os.cpu_count() or 4) * 2))
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -426,7 +427,8 @@ def _render_plan(
                 entry.name.lower(),
             ),
         ),
-        show_unchanged=render_options.show_unchanged,
+        show_unchanged=render_options.show_unchanged
+        or render_options.has_explicit_patterns,
     )
 
     if not display_entries:
@@ -499,7 +501,12 @@ def _render_plan(
                     formatter.emit_text(f"    {colors.muted(msg)}")
 
     if dry_run:
-        formatter.emit_text(colors.muted(PLAN_TIP_MESSAGE))
+        tip = (
+            PLAN_TIP_MESSAGE_FILTERED
+            if render_options.has_explicit_patterns
+            else PLAN_TIP_MESSAGE
+        )
+        formatter.emit_text(colors.muted(tip))
 
 
 def _emit_plan_output(
@@ -525,7 +532,8 @@ def _emit_plan_output(
 
     display_entries = _filter_entries_for_display(
         plan.entries,
-        show_unchanged=render_options.show_unchanged,
+        show_unchanged=render_options.show_unchanged
+        or render_options.has_explicit_patterns,
     )
 
     for entry in display_entries:
@@ -1469,6 +1477,7 @@ def _sync_impl(
     verbosity_level = clamp(verbosity, 0, 2)
     render_options = PlanRenderOptions(
         show_unchanged=show_unchanged,
+        has_explicit_patterns=not sync_all and bool(repo_patterns),
         summary_only=summary_only,
         long=long_view,
         verbosity=verbosity_level,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1741,14 +1741,17 @@ def test_sync_dry_run_plan_human(
     tmp_path: pathlib.Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
     user_path: pathlib.Path,
     config_path: pathlib.Path,
     git_repo: GitSync,
 ) -> None:
     """Validate human-readable plan output variants."""
     if xfail:
-        pytest.xfail(
-            "explicit filter patterns do not yet auto-show unchanged repos",
+        request.applymarker(
+            pytest.mark.xfail(
+                reason="explicit filter patterns do not yet auto-show unchanged repos",
+            ),
         )
     if set_no_color:
         monkeypatch.setenv("NO_COLOR", "1")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1657,7 +1657,6 @@ DRY_RUN_PLAN_FIXTURES: list[DryRunPlanFixture] = [
         cli_args=["sync", "--dry-run", "my_git_repo"],
         pre_sync=True,
         expected_contains=["Plan: 0 to clone (+)", "✓ my_git_repo"],
-        xfail=True,
     ),
     DryRunPlanFixture(
         test_id="long-format",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1627,6 +1627,7 @@ class DryRunPlanFixture(t.NamedTuple):
     plan_entries: list[PlanEntry] | None = None
     plan_summary: PlanSummary | None = None
     set_no_color: bool = True
+    xfail: bool = False
 
 
 DRY_RUN_PLAN_FIXTURES: list[DryRunPlanFixture] = [
@@ -1650,6 +1651,13 @@ DRY_RUN_PLAN_FIXTURES: list[DryRunPlanFixture] = [
         cli_args=["sync", "--dry-run", "--show-unchanged", "my_git_repo"],
         pre_sync=True,
         expected_contains=["Plan: 0 to clone (+)", "✓ my_git_repo"],
+    ),
+    DryRunPlanFixture(
+        test_id="unchanged-implicit-filter",
+        cli_args=["sync", "--dry-run", "my_git_repo"],
+        pre_sync=True,
+        expected_contains=["Plan: 0 to clone (+)", "✓ my_git_repo"],
+        xfail=True,
     ),
     DryRunPlanFixture(
         test_id="long-format",
@@ -1729,6 +1737,7 @@ def test_sync_dry_run_plan_human(
     plan_entries: list[PlanEntry] | None,
     plan_summary: PlanSummary | None,
     set_no_color: bool,
+    xfail: bool,
     tmp_path: pathlib.Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -1737,6 +1746,10 @@ def test_sync_dry_run_plan_human(
     git_repo: GitSync,
 ) -> None:
     """Validate human-readable plan output variants."""
+    if xfail:
+        pytest.xfail(
+            "explicit filter patterns do not yet auto-show unchanged repos",
+        )
     if set_no_color:
         monkeypatch.setenv("NO_COLOR", "1")
 


### PR DESCRIPTION
## Summary

- **Fix** a confusing DX gap: `vcspull sync tanstack-* --dry-run` matched 5 repos but only displayed the 1 needing action — the 4 unchanged repos were hidden unless `--show-unchanged` was passed, even though the user had already scoped the command to specific repos.
- **Add** `has_explicit_patterns` to `PlanRenderOptions`: computed as `not sync_all and bool(repo_patterns)` in `sync()`, propagated to both the human and JSON/NDJSON render paths.
- **Improve** tip message: suppress the `--show-unchanged` hint when unchanged rows are already visible due to explicit filtering; show a shorter "run without --dry-run to apply" tip instead.
- **Add** `xfail` field and `request.applymarker` support to `DryRunPlanFixture` / `test_sync_dry_run_plan_human` for per-fixture conditional xfail without stopping test execution.

## Design decisions

**OR semantics at the call site**: `show_unchanged or has_explicit_patterns` is passed to `_filter_entries_for_display()` rather than changing the function's own signature — the helper stays minimal and doesn't need to know about the concept of "explicit patterns".

**`--all` unaffected**: `has_explicit_patterns` is only `True` when `repo_patterns` is non-empty and `sync_all` is `False`. Bulk `--all` dry-runs retain the hide-unchanged default.

**`request.applymarker` over `pytest.xfail()`**: imperative `pytest.xfail()` short-circuits execution and can never become XPASS. `request.applymarker` applies the marker but still runs the test body, so the fixture transitions XFAIL → XPASS → PASS cleanly across the three-commit workflow.

## Before / After

Before:
```
Progress: 5/5 +:0 ~:1 ✓:4 ⚠:0 ✗:0
Plan: 0 to clone (+), 1 to update (~), 4 unchanged (✓), 0 blocked (⚠), 0 errors (✗)

~/study/typescript/
  ~ tanstack-router  ~/study/typescript/tanstack-router  remote state unknown; use --fetch
Tip: run without --dry-run to apply. Use --show-unchanged to include ✓ rows.
```

After:
```
Progress: 5/5 +:0 ~:1 ✓:4 ⚠:0 ✗:0
Plan: 0 to clone (+), 1 to update (~), 4 unchanged (✓), 0 blocked (⚠), 0 errors (✗)

~/study/typescript/
  ~ tanstack-router  ~/study/typescript/tanstack-router  remote state unknown; use --fetch
  ✓ tanstack-devtools  ~/study/typescript/tanstack-devtools
  ✓ tanstack-store     ~/study/typescript/tanstack-store
  ✓ tanstack-table     ~/study/typescript/tanstack-table
  ✓ tanstack-virtual   ~/study/typescript/tanstack-virtual
Tip: run without --dry-run to apply.
```

## Test plan

- [x] `unchanged-implicit-filter` — `--dry-run` with explicit name pattern and pre-synced repo shows `✓` row without `--show-unchanged`
- [x] `unchanged-show` — existing `--show-unchanged` flag still works
- [x] `uv run ruff check . --fix --show-fixes` — no lint errors
- [x] `uv run ruff format .` — no formatting changes
- [x] `uv run mypy` — no type errors
- [x] `uv run py.test --reruns 0` — full suite passes