### PR TITLE
chore(deps[libvcs]): track vcs_gitconfig fixture rename

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,10 @@ $ uvx --from 'vcspull' --prerelease allow vcspull
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Breaking changes
+
+- Bump minimum libvcs from 0.40.0 to 0.41.0 (#548)
+
 ### Documentation
 
 - Bump gp-sphinx docs stack to v0.0.1a16 — docs site now renders

--- a/conftest.py
+++ b/conftest.py
@@ -38,7 +38,7 @@ def add_doctest_fixtures(
 def setup(
     request: pytest.FixtureRequest,
     monkeypatch: pytest.MonkeyPatch,
-    gitconfig: pathlib.Path,
+    vcs_gitconfig: pathlib.Path,
     set_home: pathlib.Path,
     xdg_config_path: pathlib.Path,
     git_commit_envvars: dict[str, str],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ keywords = [
 ]
 homepage = "https://vcspull.git-pull.com"
 dependencies = [
-  "libvcs>=0.40.0,<0.41.0",
+  "libvcs>=0.41.0,<0.42.0",
   "colorama>=0.3.9",
   "PyYAML>=6.0"
 ]

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -37,7 +37,7 @@ def test_git_commit_envvars_in_environment(
 
 def test_home_contains_gitconfig(
     set_home: pathlib.Path,
-    gitconfig: pathlib.Path,
+    vcs_gitconfig: pathlib.Path,
 ) -> None:
     """HOME should point to a directory containing .gitconfig."""
     home = os.environ.get("HOME", "")
@@ -136,7 +136,7 @@ import pytest
 def setup(
     request: pytest.FixtureRequest,
     monkeypatch: pytest.MonkeyPatch,
-    gitconfig: pathlib.Path,
+    vcs_gitconfig: pathlib.Path,
     set_home: pathlib.Path,
     git_commit_envvars: dict[str, str],
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -577,14 +577,14 @@ wheels = [
 
 [[package]]
 name = "libvcs"
-version = "0.40.0"
+version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/a1/080912d310e86f8f597ab6033e5fd4d3e798aac3f5ec5cd992cfbffd0ecd/libvcs-0.40.0.tar.gz", hash = "sha256:a6dcfce94d3a7ed7212a5830ebe90f3383e7038606fbf9cd39db35d87fb02ea8", size = 617387, upload-time = "2026-04-25T18:59:13.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/fd/71d6d983e3292c0d55d2755b823d1f4159ddbd5ed422735bf9def0bc0ee9/libvcs-0.41.0.tar.gz", hash = "sha256:e5af9dba8f524d61349c4ebd93451fde9d4c996a77fb52cae7f9ea2b970d1137", size = 623333, upload-time = "2026-05-10T12:51:14.768Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/eb/ece616f90f807de6fd77e1680daa4fd11913b5ec7c6a77c09fe372675eda/libvcs-0.40.0-py3-none-any.whl", hash = "sha256:5f3340b64211a971d033b7358a669a9a68bb7e800f3413dd8cef668ec1226c5a", size = 101669, upload-time = "2026-04-25T18:59:11.847Z" },
+    { url = "https://files.pythonhosted.org/packages/57/97/4e274f0bbc9c888cf042e60957fa7fc89618ff86a64b07e3a99792048218/libvcs-0.41.0-py3-none-any.whl", hash = "sha256:e5c38226b0b30d723649039bead365217be345b7c3caf4eb3fda18a1c8facbea", size = 101680, upload-time = "2026-05-10T12:51:12.76Z" },
 ]
 
 [[package]]
@@ -1714,7 +1714,7 @@ typings = [
 [package.metadata]
 requires-dist = [
     { name = "colorama", specifier = ">=0.3.9" },
-    { name = "libvcs", specifier = ">=0.40.0,<0.41.0" },
+    { name = "libvcs", specifier = ">=0.41.0,<0.42.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary

Tracks libvcs's pytest plugin fixture rename ([libvcs#528](https://github.com/vcs-python/libvcs/issues/528) / [libvcs#529](https://github.com/vcs-python/libvcs/pull/529)).

libvcs renames its `gitconfig` / `hgconfig` / `set_gitconfig` / `set_hgconfig` pytest fixtures to `vcs_gitconfig` / `vcs_hgconfig` / `set_vcs_gitconfig` / `set_vcs_hgconfig` to vacate the namespace that collided with the third-party `pytest-gitconfig` plugin. vcspull only references one of these fixtures (`gitconfig`, in three places), so the test-side change is small.

## Changes

- `conftest.py:setup()` — autouse fixture now requests `vcs_gitconfig`
- `tests/test_fixtures.py::test_home_contains_gitconfig` — parameter rename
- `tests/test_fixtures.py::test_pytester_git_commit_in_isolated_run` — embedded conftest text updates the parameter name in the spawned pytester run
- `pyproject.toml` — bump `libvcs` constraint to `>=0.41.0,<0.42.0`
- `pyproject.toml` — add `[tool.uv.sources]` tracking the libvcs branch until 0.41.0 ships on PyPI; **drop this section in a follow-up after libvcs 0.41.0 release**
- `uv.lock` — refresh, pins to libvcs branch commit `74dbbae`
- `CHANGES` — Development entry under v1.60.x

## Test plan

- [x] `uv lock` — resolved 92 packages, libvcs pinned to branch commit
- [x] `uv sync --all-extras` — clean
- [x] `uv run ruff format .` / `uv run ruff check .` — all checks passed
- [x] `uv run mypy` — no issues found in 86 source files
- [x] `uv run pytest` — 1028 passed (with 27 syrupy snapshots)

## Follow-up

Once libvcs 0.41.0 ships on PyPI, open a follow-up PR removing the `[tool.uv.sources]` block — the version constraint alone will then resolve correctly from PyPI.
