### PR TITLE
tests(cli[sync_sigint]) Anchor subprocess to vcspull's resolved location

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,15 @@ $ uvx --from 'vcspull' --prerelease allow vcspull
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Development
+
+#### Test suite works under distro relative-`PYTHONPATH` builds (#549)
+
+Distributions that test built wheels by staging them into a directory
+and pointing pytest at that directory via a relative `PYTHONPATH` entry
+from the source tree (the common Arch Linux PKGBUILD pattern) can now
+run vcspull's full test suite end to end.
+
 ## vcspull v1.60.0 (2026-05-18)
 
 vcspull v1.60.0 is a maintenance release for the May 2026 docs and

--- a/tests/cli/test_sync_sigint.py
+++ b/tests/cli/test_sync_sigint.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import pathlib
 import signal
 import subprocess
 import sys
@@ -55,7 +57,24 @@ def test_exit_on_sigint_produces_wifsignaled_sigint() -> None:
         "    _exit_on_sigint()\n"
     )
 
-    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    # Pin the child's import path to wherever the parent loaded vcspull from.
+    # The root conftest's autouse ``cwd_default`` chdirs every test into a
+    # per-test ``tmp_path``, which the subprocess inherits as its CWD. Build
+    # environments that hand vcspull to pytest via a *relative* ``PYTHONPATH``
+    # entry (e.g. Arch's ``tmp_install/usr/lib/pythonX.Y/site-packages``)
+    # would then resolve that entry against the tmp dir and fail to import
+    # vcspull. Prepending the parent's resolved package dir keeps the child
+    # importable regardless of the surrounding install style.
+    vcspull_spec = importlib.util.find_spec("vcspull")
+    assert vcspull_spec is not None and vcspull_spec.origin is not None
+    vcspull_parent = str(pathlib.Path(vcspull_spec.origin).resolve().parent.parent)
+    env = {
+        **os.environ,
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONPATH": os.pathsep.join(
+            p for p in (vcspull_parent, os.environ.get("PYTHONPATH", "")) if p
+        ),
+    }
 
     proc = subprocess.run(
         [sys.executable, "-c", runner],


### PR DESCRIPTION
## Summary

- **Fix** a test failure for distros (e.g. Arch Linux) that run vcspull's test suite against a staged-install directory referenced via a *relative* `PYTHONPATH` entry.
- **Anchor** the subprocess spawned by `test_exit_on_sigint_produces_wifsignaled_sigint` to `vcspull`'s actual install location via `importlib.util.find_spec`, then prepend that absolute directory to the child's `PYTHONPATH`.
- **Preserve** the original `PYTHONPATH` so other build environments remain unaffected.

## Root cause

Distros stage built wheels into a tree like `tmp_install/usr/lib/pythonX.Y/site-packages/` and run pytest from the source dir with a relative `PYTHONPATH=tmp_install/usr/lib/pythonX.Y/site-packages:`. The project's root `conftest.py` has an autouse `cwd_default` fixture that `monkeypatch.chdir(tmp_path)`s every test. When `test_exit_on_sigint_produces_wifsignaled_sigint` calls `subprocess.run([sys.executable, "-c", runner], env={**os.environ, ...})`, the child inherits the per-test `tmp_path` as its CWD *and* the relative `PYTHONPATH`. The child resolves the relative entry against the tmp dir, finds nothing, and `from vcspull.cli.sync import _exit_on_sigint` fails with `ModuleNotFoundError: No module named 'vcspull'`. `uv run pytest` masks the bug because the venv exposes `vcspull` via absolute site-packages.

Reproduced locally by staging the built wheel into `./tmp_install/...` and running `PYTHONNOUSERSITE=1 PYTHONPATH="\$STAGE:" python3.14 -s -m pytest tests/cli/test_sync_sigint.py` — yields the same stderr as the original failure.

## Test plan

- [x] \`uv run pytest tests/cli/test_sync_sigint.py -v\` — the target test passes in the dev env
- [x] \`PYTHONNOUSERSITE=1 PYTHONPATH=\"\$STAGE:\" python3.14 -s -m pytest tests/cli/test_sync_sigint.py\` — same test passes under a relative-\`PYTHONPATH\` staged-install setup (previously failed with \`ModuleNotFoundError\`)
- [x] \`uv run pytest\` — full suite passes
- [x] \`uv run ruff format .\` — clean
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy\` — clean