### PR TITLE
add/discover: capture rev and shallow state when importing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,22 @@ $ uvx --from 'vcspull' --prerelease allow vcspull
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+#### Pin a repository to a fixed ref (#551)
+
+`vcspull add` and `vcspull discover` accept `--pin <ref>` to record a commit,
+tag, or branch as a per-repository `rev:`. A later `sync` checks out that ref,
+so a config can capture a reproducible snapshot instead of tracking the branch
+tip. See {ref}`configuration` for the `rev:` key.
+
+#### Detect and persist shallow clones (#550)
+
+`add` and `discover` now notice when a checkout is shallow and record
+`shallow: true`, which makes `sync` clone with `--depth 1`—saving disk and time
+across large workspaces. Pass `--shallow` to force it on even for a full
+checkout. See {ref}`configuration` for the `shallow:` key.
+
 ## vcspull v1.60.1 (2026-05-16)
 
 ### Development

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -119,6 +119,42 @@ Optional fields:
 
 See {ref}`cli-worktree` for full command documentation.
 
+## Revision pinning
+
+A `rev:` key pins a repository to a commit, tag, or branch, which {ref}`cli-sync`
+checks out. This lets a config capture a reproducible snapshot instead of
+tracking the branch tip. It is distinct from `options.pin` (see
+{ref}`config-pin`), which guards the config entry from being overwritten rather
+than pinning a git ref.
+
+```yaml
+~/code/:
+  flask:
+    repo: git+https://github.com/pallets/flask.git
+    rev: v3.0.0
+```
+
+`vcspull add <path> --pin <ref>` and `vcspull discover <dir> --pin <ref>` record
+this key when importing an existing checkout. See {ref}`cli-add` and
+{ref}`cli-discover`.
+
+## Shallow clones
+
+A `shallow: true` key makes {ref}`cli-sync` clone the repository with
+`--depth 1`, trading git history for disk and time—useful for workspaces with
+many repositories.
+
+```yaml
+~/code/:
+  flask:
+    repo: git+https://github.com/pallets/flask.git
+    shallow: true
+```
+
+`vcspull add` and `vcspull discover` detect an existing shallow checkout
+automatically and record `shallow: true`; the `--shallow` flag forces it on even
+for a full checkout.
+
 (config-pin)=
 
 ## Repository pinning

--- a/src/vcspull/cli/__init__.py
+++ b/src/vcspull/cli/__init__.py
@@ -538,6 +538,8 @@ def cli(_args: list[str] | None = None) -> None:
             dry_run=args.dry_run,
             merge_duplicates=args.merge_duplicates,
             include_worktrees=getattr(args, "include_worktrees", False),
+            rev=getattr(args, "pin", None),
+            shallow=getattr(args, "shallow", False),
         )
     elif args.subparser_name == "fmt":
         format_config_file(

--- a/src/vcspull/cli/add.py
+++ b/src/vcspull/cli/add.py
@@ -19,7 +19,9 @@ from vcspull._internal.config_reader import (
 )
 from vcspull._internal.private_path import PrivatePath
 from vcspull.config import (
+    build_repo_entry,
     canonicalize_workspace_path,
+    detect_git_shallow,
     expand_dir,
     find_home_config_files,
     get_pin_reason,
@@ -110,6 +112,21 @@ def create_add_subparser(parser: argparse.ArgumentParser) -> None:
         "--url",
         dest="url",
         help="Repository URL to record (overrides detected remotes)",
+    )
+    parser.add_argument(
+        "--pin",
+        dest="pin",
+        metavar="REF",
+        help="Record a fixed commit, tag, or branch as the repository 'rev'",
+    )
+    parser.add_argument(
+        "--shallow",
+        dest="shallow",
+        action="store_true",
+        help=(
+            "Record 'shallow: true' (clone --depth 1 on sync). A shallow "
+            "checkout is detected automatically; this forces it on."
+        ),
     )
     parser.add_argument(
         "-f",
@@ -437,6 +454,26 @@ def handle_add_command(args: argparse.Namespace) -> None:
         display_path,
         Style.RESET_ALL,
     )
+    pin_rev = getattr(args, "pin", None)
+    if pin_rev:
+        log.info(
+            "  %s•%s rev: %s%s%s",
+            Fore.BLUE,
+            Style.RESET_ALL,
+            Fore.YELLOW,
+            pin_rev,
+            Style.RESET_ALL,
+        )
+
+    shallow = bool(getattr(args, "shallow", False)) or detect_git_shallow(repo_path)
+    if shallow:
+        log.info(
+            "  %s•%s shallow: %strue%s",
+            Fore.BLUE,
+            Style.RESET_ALL,
+            Fore.YELLOW,
+            Style.RESET_ALL,
+        )
 
     prompt_text = f"{Fore.CYAN}?{Style.RESET_ALL} Import this repository? [y/N]: "
 
@@ -479,6 +516,8 @@ def handle_add_command(args: argparse.Namespace) -> None:
         workspace_root_path=workspace_root_input,
         dry_run=args.dry_run,
         merge_duplicates=args.merge_duplicates,
+        rev=getattr(args, "pin", None),
+        shallow=shallow,
     )
 
 
@@ -491,6 +530,8 @@ def add_repo(
     dry_run: bool,
     *,
     merge_duplicates: bool = True,
+    rev: str | None = None,
+    shallow: bool = False,
 ) -> None:
     """Add a repository to the vcspull configuration.
 
@@ -508,6 +549,10 @@ def add_repo(
         Workspace root to use in config
     dry_run : bool
         If True, preview changes without writing
+    rev : str | None
+        Commit, tag, or branch to record as the repository ``rev``.
+    shallow : bool
+        If ``True``, record ``shallow: true`` for the repository.
     """
     # Determine config file
     config_file_path: pathlib.Path
@@ -585,7 +630,7 @@ def add_repo(
         preserve_cwd_label=explicit_dot,
     )
 
-    new_repo_entry = {"repo": url}
+    new_repo_entry = build_repo_entry(url, rev=rev, shallow=shallow)
 
     def _ensure_workspace_label_for_merge(
         config_data: dict[str, t.Any],

--- a/src/vcspull/cli/discover.py
+++ b/src/vcspull/cli/discover.py
@@ -16,7 +16,9 @@ from colorama import Fore, Style
 from vcspull._internal.config_reader import DuplicateAwareConfigReader
 from vcspull._internal.private_path import PrivatePath
 from vcspull.config import (
+    build_repo_entry,
     canonicalize_workspace_path,
+    detect_git_shallow,
     expand_dir,
     find_home_config_files,
     get_pin_reason,
@@ -37,6 +39,15 @@ class DiscoverAction(enum.Enum):
     ADD = "add"
     SKIP_EXISTING = "skip_existing"
     SKIP_PINNED = "skip_pinned"
+
+
+class _FoundRepo(t.NamedTuple):
+    """A git checkout found while scanning, with its resolved shallow state."""
+
+    name: str
+    url: str
+    workspace_path: pathlib.Path
+    shallow: bool
 
 
 def _classify_discover_action(existing_entry: t.Any) -> DiscoverAction:
@@ -235,6 +246,24 @@ def create_discover_subparser(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--pin",
+        dest="pin",
+        metavar="REF",
+        help=(
+            "Record a fixed commit, tag, or branch as the 'rev' for every "
+            "discovered repository"
+        ),
+    )
+    parser.add_argument(
+        "--shallow",
+        dest="shallow",
+        action="store_true",
+        help=(
+            "Record 'shallow: true' for discovered repositories. Shallow "
+            "checkouts are detected automatically; this forces it on for all."
+        ),
+    )
+    parser.add_argument(
         "--recursive",
         "-r",
         action="store_true",
@@ -306,6 +335,8 @@ def discover_repos(
     *,
     merge_duplicates: bool = True,
     include_worktrees: bool = False,
+    rev: str | None = None,
+    shallow: bool = False,
 ) -> None:
     """Scan filesystem for git repositories and add to vcspull config.
 
@@ -323,6 +354,12 @@ def discover_repos(
         Whether to skip confirmation prompt
     dry_run : bool
         If True, preview changes without writing
+    rev : str | None
+        Commit, tag, or branch to record as the ``rev`` for every discovered
+        repository.
+    shallow : bool
+        If ``True``, force ``shallow: true`` for every discovered repository;
+        otherwise shallow state is auto-detected per repository.
     """
     scan_dir = expand_dir(pathlib.Path(scan_dir_str))
 
@@ -479,7 +516,7 @@ def discover_repos(
     for message in merge_conflicts:
         log.warning(message)
 
-    found_repos: list[tuple[str, str, pathlib.Path]] = []
+    found_repos: list[_FoundRepo] = []
 
     override_workspace_path: pathlib.Path | None = None
     if workspace_root_override:
@@ -517,7 +554,10 @@ def discover_repos(
                     continue
 
                 workspace_path = override_workspace_path or scan_dir
-                found_repos.append((repo_name, repo_url, workspace_path))
+                repo_shallow = shallow or detect_git_shallow(repo_path)
+                found_repos.append(
+                    _FoundRepo(repo_name, repo_url, workspace_path, repo_shallow),
+                )
     else:
         for item in scan_dir.iterdir():
             git_path = item / ".git"
@@ -542,7 +582,10 @@ def discover_repos(
                     continue
 
                 workspace_path = override_workspace_path or scan_dir
-                found_repos.append((repo_name, repo_url, workspace_path))
+                repo_shallow = shallow or detect_git_shallow(item)
+                found_repos.append(
+                    _FoundRepo(repo_name, repo_url, workspace_path, repo_shallow),
+                )
 
     if not found_repos:
         log.info(
@@ -555,10 +598,11 @@ def discover_repos(
         )
         return
 
-    repos_to_add: list[tuple[str, str, pathlib.Path]] = []
-    existing_repos: list[tuple[str, str, pathlib.Path]] = []
+    repos_to_add: list[_FoundRepo] = []
+    existing_repos: list[_FoundRepo] = []
 
-    for name, url, workspace_path in found_repos:
+    for found in found_repos:
+        name, url, workspace_path = found.name, found.url, found.workspace_path
         workspace_label = workspace_map.get(workspace_path)
         if workspace_label is None:
             workspace_label = workspace_root_label(
@@ -586,9 +630,9 @@ def discover_repos(
                     name,
                     f" ({reason})" if reason else "",
                 )
-            existing_repos.append((name, url, workspace_path))
+            existing_repos.append(found)
         else:
-            repos_to_add.append((name, url, workspace_path))
+            repos_to_add.append(found)
 
     if existing_repos:
         # Show summary only when there are many existing repos
@@ -611,7 +655,7 @@ def discover_repos(
                 len(existing_repos),
                 Style.RESET_ALL,
             )
-            for name, url, workspace_path in existing_repos:
+            for name, url, workspace_path, _shallow in existing_repos:
                 workspace_label = workspace_map.get(workspace_path)
                 if workspace_label is None:
                     workspace_label = workspace_root_label(
@@ -685,7 +729,7 @@ def discover_repos(
         "preview" if dry_run else "import",
         Style.RESET_ALL,
     )
-    for repo_name, repo_url, _determined_base_key in repos_to_add:
+    for repo_name, repo_url, _determined_base_key, repo_shallow in repos_to_add:
         log.info(
             "  %s+%s %s%s%s (%s%s%s)",
             Fore.GREEN,
@@ -697,6 +741,23 @@ def discover_repos(
             repo_url,
             Style.RESET_ALL,
         )
+        if rev:
+            log.info(
+                "    %s•%s rev: %s%s%s",
+                Fore.BLUE,
+                Style.RESET_ALL,
+                Fore.YELLOW,
+                rev,
+                Style.RESET_ALL,
+            )
+        if repo_shallow:
+            log.info(
+                "    %s•%s shallow: %strue%s",
+                Fore.BLUE,
+                Style.RESET_ALL,
+                Fore.YELLOW,
+                Style.RESET_ALL,
+            )
 
     if dry_run:
         log.info(
@@ -717,7 +778,7 @@ def discover_repos(
             log.info("%s✗%s Aborted by user.", Fore.RED, Style.RESET_ALL)
             return
 
-    for repo_name, repo_url, workspace_path in repos_to_add:
+    for repo_name, repo_url, workspace_path, repo_shallow in repos_to_add:
         workspace_label = workspace_map.get(workspace_path)
         if workspace_label is None:
             workspace_label = workspace_root_label(
@@ -739,7 +800,11 @@ def discover_repos(
             continue
 
         if repo_name not in raw_config[workspace_label]:
-            raw_config[workspace_label][repo_name] = {"repo": repo_url}
+            raw_config[workspace_label][repo_name] = build_repo_entry(
+                repo_url,
+                rev=rev,
+                shallow=repo_shallow,
+            )
             log.info(
                 "%s+%s Importing %s'%s'%s (%s%s%s) under '%s%s%s'.",
                 Fore.GREEN,

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -1924,6 +1924,12 @@ def update_repo(
 
     repo_dict["progress_callback"] = progress_callback or progress_cb
 
+    # ``shallow`` is the vcspull-facing config key for a depth-1 clone. libvcs
+    # GitSync only initializes ``git_shallow`` from kwargs as a default and
+    # drops it when actually passed, so capture the flag here and apply it as an
+    # attribute after construction (below) rather than forwarding the kwarg.
+    git_shallow = bool(repo_dict.pop("shallow", False))
+
     if repo_dict.get("vcs") is None:
         vcs = guess_vcs(url=repo_dict["url"])
         if vcs is None:
@@ -1932,6 +1938,8 @@ def update_repo(
         repo_dict["vcs"] = vcs
 
     r: GitSync | HgSync | SvnSync = create_project(**repo_dict)
+    if git_shallow and isinstance(r, GitSync):
+        r.git_shallow = True
     if repo_dict.get("vcs") == "git":
         result = r.update_repo(set_remotes=True)
     else:

--- a/src/vcspull/config.py
+++ b/src/vcspull/config.py
@@ -9,6 +9,7 @@ import fnmatch
 import logging
 import os
 import pathlib
+import subprocess
 import tempfile
 import typing as t
 from collections.abc import Callable
@@ -844,6 +845,103 @@ def save_config_json(config_file_path: pathlib.Path, data: dict[t.Any, t.Any]) -
         indent=2,
     )
     _atomic_write(config_file_path, json_content)
+
+
+def detect_git_shallow(repo_path: pathlib.Path) -> bool:
+    """Return whether a local git checkout is shallow.
+
+    Uses ``git rev-parse --is-shallow-repository`` (git 2.15+), falling back to
+    the presence of ``.git/shallow``. Any error (missing binary, non-git path)
+    is treated as "not shallow".
+
+    Parameters
+    ----------
+    repo_path : pathlib.Path
+        Path to the local git repository.
+
+    Returns
+    -------
+    bool
+        ``True`` if the checkout is shallow, else ``False``.
+
+    Examples
+    --------
+    A full clone is not shallow:
+
+    >>> remote = create_git_remote_repo()
+    >>> full = tmp_path / "full"
+    >>> _ = subprocess.run(
+    ...     ["git", "clone", f"file://{remote}", str(full)],
+    ...     check=True, capture_output=True,
+    ... )
+    >>> detect_git_shallow(full)
+    False
+
+    A ``--depth 1`` clone is shallow:
+
+    >>> shallow = tmp_path / "shallow"
+    >>> _ = subprocess.run(
+    ...     ["git", "clone", "--depth", "1", f"file://{remote}", str(shallow)],
+    ...     check=True, capture_output=True,
+    ... )
+    >>> detect_git_shallow(shallow)
+    True
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "--is-shallow-repository"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return (repo_path / ".git" / "shallow").exists()
+
+    return result.stdout.strip() == "true"
+
+
+def build_repo_entry(
+    url: str,
+    *,
+    rev: str | None = None,
+    shallow: bool = False,
+) -> dict[str, t.Any]:
+    """Build a raw per-repository config entry for ``add``/``discover``.
+
+    Centralizes the entry shape written by both subcommands so the recorded
+    keys stay consistent.
+
+    Parameters
+    ----------
+    url : str
+        VCS URL in vcspull format, e.g. ``git+https://github.com/u/r.git``.
+    rev : str | None
+        Commit, tag, or branch to pin via the ``rev`` key. Omitted when falsy.
+    shallow : bool
+        If ``True``, record ``shallow: true`` (clone ``--depth 1`` on sync).
+
+    Returns
+    -------
+    dict
+        Mapping ready to store under a workspace root in the config.
+
+    Examples
+    --------
+    >>> build_repo_entry("git+https://github.com/u/r.git")
+    {'repo': 'git+https://github.com/u/r.git'}
+
+    >>> build_repo_entry("git+https://github.com/u/r.git", rev="v1.0.0")
+    {'repo': 'git+https://github.com/u/r.git', 'rev': 'v1.0.0'}
+
+    >>> build_repo_entry("git+https://github.com/u/r.git", shallow=True)
+    {'repo': 'git+https://github.com/u/r.git', 'shallow': True}
+    """
+    entry: dict[str, t.Any] = {"repo": url}
+    if rev:
+        entry["rev"] = rev
+    if shallow:
+        entry["shallow"] = True
+    return entry
 
 
 def save_config(config_file_path: pathlib.Path, data: dict[t.Any, t.Any]) -> None:

--- a/src/vcspull/types.py
+++ b/src/vcspull/types.py
@@ -172,6 +172,16 @@ class RepoEntryDict(TypedDict):
 
         repo: git+git@github.com:user/myrepo.git
 
+    Pinned to a ref::
+
+        repo: git+git@github.com:user/myrepo.git
+        rev: v1.2.3
+
+    Shallow clone::
+
+        repo: git+git@github.com:user/myrepo.git
+        shallow: true
+
     With pin options::
 
         repo: git+git@github.com:user/myrepo.git
@@ -183,6 +193,16 @@ class RepoEntryDict(TypedDict):
 
     repo: str
     """VCS URL in vcspull format, e.g. ``git+git@github.com:user/repo.git``."""
+
+    rev: NotRequired[str]
+    """Commit, tag, or branch to check out on sync (libvcs ``rev``).
+
+    Distinct from ``options.pin``, which guards config mutation rather than
+    pinning a git ref.
+    """
+
+    shallow: NotRequired[bool]
+    """If ``True``, clone with ``--depth 1`` on sync (libvcs ``git_shallow``)."""
 
     options: NotRequired[RepoOptionsDict]
     """Mutation policy. Nested under ``options:`` to avoid polluting VCS fields."""
@@ -210,6 +230,8 @@ class ConfigDict(TypedDict):
     path: pathlib.Path
     url: str
     workspace_root: str
+    rev: NotRequired[str | None]
+    shallow: NotRequired[bool | None]
     remotes: NotRequired[GitSyncRemoteDict | None]
     shell_command_after: NotRequired[list[str] | None]
     worktrees: NotRequired[list[WorktreeConfigDict] | None]

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -43,6 +43,8 @@ class AddRepoFixture(t.NamedTuple):
     preexisting_config: dict[str, t.Any] | None
     expected_in_config: dict[str, t.Any]
     expected_log_messages: list[str]
+    rev: str | None = None
+    shallow: bool = False
 
 
 def init_git_repo(repo_path: pathlib.Path, remote_url: str | None) -> None:
@@ -161,6 +163,46 @@ ADD_REPO_FIXTURES: list[AddRepoFixture] = [
         },
         expected_log_messages=["Successfully added 'extra'"],
     ),
+    AddRepoFixture(
+        test_id="add-with-pin-rev",
+        name="pinnedproject",
+        url="git+https://github.com/user/pinnedproject.git",
+        workspace_root=None,
+        path_relative="pinnedproject",
+        dry_run=False,
+        use_default_config=False,
+        preexisting_config=None,
+        expected_in_config={
+            "~/": {
+                "pinnedproject": {
+                    "repo": "git+https://github.com/user/pinnedproject.git",
+                    "rev": "v1.2.3",
+                },
+            },
+        },
+        expected_log_messages=["Successfully added 'pinnedproject'"],
+        rev="v1.2.3",
+    ),
+    AddRepoFixture(
+        test_id="add-with-shallow",
+        name="shallowproject",
+        url="git+https://github.com/user/shallowproject.git",
+        workspace_root=None,
+        path_relative="shallowproject",
+        dry_run=False,
+        use_default_config=False,
+        preexisting_config=None,
+        expected_in_config={
+            "~/": {
+                "shallowproject": {
+                    "repo": "git+https://github.com/user/shallowproject.git",
+                    "shallow": True,
+                },
+            },
+        },
+        expected_log_messages=["Successfully added 'shallowproject'"],
+        shallow=True,
+    ),
 ]
 
 
@@ -180,6 +222,8 @@ def test_add_repo(
     preexisting_config: dict[str, t.Any] | None,
     expected_in_config: dict[str, t.Any],
     expected_log_messages: list[str],
+    rev: str | None,
+    shallow: bool,
     tmp_path: pathlib.Path,
     monkeypatch: MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -217,6 +261,8 @@ def test_add_repo(
         path=path_argument,
         workspace_root_path=workspace_root,
         dry_run=dry_run,
+        rev=rev,
+        shallow=shallow,
     )
 
     # Check log messages

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -46,6 +46,8 @@ class DiscoverFixture(t.NamedTuple):
     expected_workspace_labels: set[str] | None
     merge_duplicates: bool
     preexisting_yaml: str | None
+    pin: str | None = None
+    shallow: bool = False
 
 
 DISCOVER_FIXTURES: list[DiscoverFixture] = [
@@ -198,6 +200,43 @@ DISCOVER_FIXTURES: list[DiscoverFixture] = [
   repo2:
     repo: git+https://example.com/repo2.git
 """,
+    ),
+    DiscoverFixture(
+        test_id="pin-rev-recorded",
+        repos_to_create=[
+            ("repo1", "git+https://github.com/user/repo1.git"),
+            ("repo2", "git+https://github.com/user/repo2.git"),
+        ],
+        recursive=False,
+        workspace_override=None,
+        dry_run=False,
+        yes=True,
+        expected_repo_count=2,
+        config_relpath=".vcspull.yaml",
+        preexisting_config=None,
+        user_input=None,
+        expected_workspace_labels={"~/code/"},
+        merge_duplicates=True,
+        preexisting_yaml=None,
+        pin="v2.0.0",
+    ),
+    DiscoverFixture(
+        test_id="shallow-forced",
+        repos_to_create=[
+            ("repo1", "git+https://github.com/user/repo1.git"),
+        ],
+        recursive=False,
+        workspace_override=None,
+        dry_run=False,
+        yes=True,
+        expected_repo_count=1,
+        config_relpath=".vcspull.yaml",
+        preexisting_config=None,
+        user_input=None,
+        expected_workspace_labels={"~/code/"},
+        merge_duplicates=True,
+        preexisting_yaml=None,
+        shallow=True,
     ),
 ]
 
@@ -357,6 +396,8 @@ def test_discover_repos(
     expected_workspace_labels: set[str] | None,
     merge_duplicates: bool,
     preexisting_yaml: str | None,
+    pin: str | None,
+    shallow: bool,
     tmp_path: pathlib.Path,
     monkeypatch: MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -408,6 +449,8 @@ def test_discover_repos(
         yes=yes,
         dry_run=dry_run,
         merge_duplicates=merge_duplicates,
+        rev=pin,
+        shallow=shallow,
     )
 
     if preexisting_yaml is not None or not merge_duplicates:
@@ -448,6 +491,85 @@ def test_discover_repos(
         assert total_repos == expected_repo_count, (
             f"Expected {expected_repo_count} repos, got {total_repos}"
         )
+
+        persisted_entries = [
+            entry
+            for repos in config.values()
+            if isinstance(repos, dict)
+            for entry in repos.values()
+            if isinstance(entry, dict)
+        ]
+        if pin is not None:
+            assert all(entry.get("rev") == pin for entry in persisted_entries)
+        if shallow:
+            assert all(entry.get("shallow") is True for entry in persisted_entries)
+
+
+def test_discover_detects_shallow_clone(
+    tmp_path: pathlib.Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Discover records ``shallow: true`` only for shallow checkouts."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    # A shallow clone is only meaningfully shallow when the remote carries more
+    # history than --depth requests, so seed the remote with two commits. The
+    # autouse ``setup`` fixture already injects ``git_commit_envvars`` into the
+    # environment, so the subprocess inherits a valid commit identity.
+    remote = tmp_path / "remote"
+    subprocess.run(["git", "init", "-q", str(remote)], check=True)
+    for message in ("first", "second"):
+        subprocess.run(
+            ["git", "-C", str(remote), "commit", "-q", "--allow-empty", "-m", message],
+            check=True,
+        )
+    remote_url = f"file://{remote}"
+
+    scan_dir = tmp_path / "code"
+    scan_dir.mkdir()
+    subprocess.run(
+        ["git", "clone", "-q", remote_url, str(scan_dir / "fullrepo")],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "-q",
+            # --no-local forces the standard transport so --depth is honored
+            # even when the source is on the same filesystem.
+            "--no-local",
+            "--depth",
+            "1",
+            remote_url,
+            str(scan_dir / "shallowrepo"),
+        ],
+        check=True,
+    )
+
+    config_file = tmp_path / ".vcspull.yaml"
+    discover_repos(
+        scan_dir_str=str(scan_dir),
+        config_file_path_str=str(config_file),
+        recursive=False,
+        workspace_root_override=None,
+        yes=True,
+        dry_run=False,
+    )
+
+    import yaml
+
+    config = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+    entries = {
+        name: entry
+        for repos in config.values()
+        if isinstance(repos, dict)
+        for name, entry in repos.items()
+        if isinstance(entry, dict)
+    }
+    assert "shallow" not in entries["fullrepo"]
+    assert entries["shallowrepo"]["shallow"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import textwrap
 import typing as t
 
@@ -21,7 +22,7 @@ from libvcs.sync.svn import SvnSync
 
 from vcspull._internal.config_reader import ConfigReader
 from vcspull.cli.sync import sync, update_repo
-from vcspull.config import extract_repos, filter_repos, load_configs
+from vcspull.config import detect_git_shallow, extract_repos, filter_repos, load_configs
 from vcspull.validator import is_valid_config
 
 from .helpers import write_config
@@ -433,3 +434,69 @@ def test_update_repo_hg(
 
     result = update_repo(repo_dict)
     assert isinstance(result, HgSync)
+
+
+def test_update_repo_git_shallow(
+    tmp_path: pathlib.Path,
+    create_git_remote_repo: CreateRepoFn,
+) -> None:
+    """A ``shallow: true`` config entry clones with ``--depth 1`` on sync."""
+    dummy_repo = create_git_remote_repo(
+        remote_repo_post_init=git_remote_repo_single_commit_post_init,
+    )
+    # A --depth 1 clone is only meaningfully shallow when the remote carries
+    # more history than the requested depth, so add a second commit.
+    subprocess.run(
+        ["git", "-C", str(dummy_repo), "commit", "-q", "--allow-empty", "-m", "second"],
+        check=True,
+    )
+
+    repo_dict: ConfigDict = {
+        "vcs": "git",
+        "name": "shallowclone",
+        "path": tmp_path / "checkout" / "shallowclone",
+        "url": f"git+file://{dummy_repo}",
+        "workspace_root": str(tmp_path / "checkout/"),
+        "shallow": True,
+    }
+
+    # update_repo must not raise (regression guard: ``git_shallow`` is applied
+    # as an attribute post-construction, not forwarded as a GitSync kwarg).
+    result = update_repo(repo_dict)
+    assert isinstance(result, GitSync)
+    assert detect_git_shallow(result.path) is True
+
+
+def test_update_repo_git_rev(
+    tmp_path: pathlib.Path,
+    create_git_remote_repo: CreateRepoFn,
+) -> None:
+    """A ``rev`` config entry checks out that ref on sync, not the branch tip."""
+    dummy_repo = create_git_remote_repo(
+        remote_repo_post_init=git_remote_repo_single_commit_post_init,
+    )
+    # Tag the first commit, then advance the branch so the tag != HEAD.
+    subprocess.run(["git", "-C", str(dummy_repo), "tag", "v1.0.0"], check=True)
+    subprocess.run(
+        ["git", "-C", str(dummy_repo), "commit", "-q", "--allow-empty", "-m", "second"],
+        check=True,
+    )
+    tag_sha = subprocess.run(
+        ["git", "-C", str(dummy_repo), "rev-parse", "v1.0.0"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    repo_dict: ConfigDict = {
+        "vcs": "git",
+        "name": "revclone",
+        "path": tmp_path / "checkout" / "revclone",
+        "url": f"git+file://{dummy_repo}",
+        "workspace_root": str(tmp_path / "checkout/"),
+        "rev": "v1.0.0",
+    }
+
+    result = update_repo(repo_dict)
+    assert isinstance(result, GitSync)
+    assert result.get_revision() == tag_sha


### PR DESCRIPTION
## Summary

- **Add** `--pin <ref>` to `vcspull add` and `vcspull discover` to record a fixed commit, tag, or branch as a per-repository `rev:` key, so a config can capture a reproducible snapshot instead of always tracking the branch tip. Closes #551.
- **Add** shallow-clone awareness: `add`/`discover` detect an existing shallow checkout and record `shallow: true`, and `--shallow` forces it on; `sync` then clones with `--depth 1`, saving disk and time across large workspaces. Closes #550.
- **Extend** the per-repo config schema (`RepoEntryDict`, `ConfigDict`) with top-level `rev` and `shallow` keys, alongside the existing VCS-semantic fields (`remotes`, `worktrees`, `shell_command_after`) rather than under `options:` (which governs config-mutation policy, not git state).
- **Plumb** both keys through to libvcs on sync — `rev` flows untouched to `GitSync(rev=...)`, and `shallow` is translated to `git_shallow` at the sync boundary so the config schema stays VCS-agnostic.

## Changes by area

### CLI
- **`cli/add.py`**: add `--pin REF` and `--shallow` flags; auto-detect shallow checkouts; surface the captured `rev`/`shallow` in the import preview.
- **`cli/discover.py`**: add `--pin REF` and `--shallow`; resolve shallow state per discovered repo (a `_FoundRepo` carries the resolved flag through classification to persistence).
- **`cli/__init__.py`**: forward `pin`/`shallow` args to `discover_repos`.
- **`cli/sync.py`**: translate the `shallow` config key to libvcs `git_shallow`. libvcs's `GitSync.__init__` only initializes `git_shallow` as a default and drops it when passed as a kwarg, so the flag is applied as an attribute on the constructed object instead of being forwarded.

### Schema & helpers
- **`types.py`**: add `rev`/`shallow` to `RepoEntryDict` and `ConfigDict` with field docstrings noting `rev` is distinct from `options.pin`.
- **`config.py`**: add `build_repo_entry()` (consistent entry shape for both subcommands) and `detect_git_shallow()` (`git rev-parse --is-shallow-repository`, with a `.git/shallow` fallback), each with doctests.

### Docs
- **`docs/configuration/index.md`**: "Revision pinning" and "Shallow clones" sections with YAML examples and the corresponding CLI flags.
- **`CHANGES`**: deliverable entries for #550 and #551.

## Design decisions

- **Boolean `shallow`, not numeric `depth`**: libvcs's sync path only honors a depth-1 clone (`git_shallow` → `--depth 1`); it cannot apply an arbitrary depth, so a numeric `depth: N` would be silently misleading. Follow-ups filed: vcs-python/libvcs#531 (honor arbitrary depth on sync) and #552 (persist `depth: N` once the backend supports it).
- **Top-level keys, not under `options:`**: `options:` is typed as config-mutation policy (`RepoOptionsDict`); `rev`/`shallow` are VCS-semantic and belong beside `remotes`/`worktrees`, which also lets `rev` flow transparently into libvcs.
- **`--pin` requires a value**: no bare-flag "capture current ref" mode in this change.

## Before / After

Before — `add`/`discover` recorded only the URL:

```yaml
~/code/:
  flask:
    repo: git+https://github.com/pallets/flask.git
```

After — with `--pin v3.0.0` / a detected shallow checkout:

```yaml
~/code/:
  flask:
    repo: git+https://github.com/pallets/flask.git
    rev: v3.0.0
    shallow: true
```

## Test plan

- [x] `uv run ruff check .` — lint clean
- [x] `uv run ruff format .` — formatting clean
- [x] `uv run mypy` — type-check clean
- [x] `uv run py.test --reruns 0` — full suite green
- [x] `just build-docs` — docs build succeeds
- [x] `test_add_repo[add-with-pin-rev]` / `[add-with-shallow]` — `add` persists `rev`/`shallow`
- [x] `test_discover_repos[pin-rev-recorded]` / `[shallow-forced]` — `discover` persists `rev`/`shallow`
- [x] `test_discover_detects_shallow_clone` — only the shallow checkout gets `shallow: true`; the full clone does not
- [x] Manual end-to-end: `sync` checks out the pinned tag (checked-out SHA == tag SHA) and produces a depth-1 clone for `shallow: true` (`git rev-parse --is-shallow-repository` → `true`)

Closes #550
Closes #551