### PR TITLE
py(deps) libvcs 0.42.0 -> 0.43.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,12 @@ $ uvx --from 'vcspull' --prerelease allow vcspull
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+Minimum `libvcs>=0.43.0` (was `>=0.42.0`). libvcs 0.43.0 restores
+pytest 9.1 compatibility for projects that auto-load its pytest plugin
+(#555).
+
 ## vcspull v1.62.0 (2026-05-31)
 
 vcspull v1.62.0 lets a workspace keep a small window of git history per

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ keywords = [
 ]
 homepage = "https://vcspull.git-pull.com"
 dependencies = [
-  "libvcs>=0.42.0,<0.43.0",
+  "libvcs>=0.43.0,<0.44.0",
   "colorama>=0.3.9",
   "PyYAML>=6.0"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -619,14 +619,14 @@ wheels = [
 
 [[package]]
 name = "libvcs"
-version = "0.42.0"
+version = "0.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/fc/9b3ded35c251d77780cec94dc8fa3eeb0a80b26cbe1efcdf07d973adeb17/libvcs-0.42.0.tar.gz", hash = "sha256:8744756916df1d623d056a52ad19c37e3787091570bf35a11f4f33aeba82badc", size = 631217, upload-time = "2026-05-31T15:22:05.004Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/69/9a193122017217599b65b36598e399d7537f755a598e828305609857eeae/libvcs-0.43.0.tar.gz", hash = "sha256:8b89d7f80ea6bcb5d3b4b5f07e9dd6410e5f26a5e22883f69fd812e7e12b391b", size = 631775, upload-time = "2026-06-20T19:08:09.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/93/3a602d3cf8fe1cf66f75e4002ff1d5c6163932aa9815166770b4b697b661/libvcs-0.42.0-py3-none-any.whl", hash = "sha256:83e46a834e5138e770b0787eafbf0761561ab8776152eee4da8d388a59f154bc", size = 102080, upload-time = "2026-05-31T15:22:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/76/68/cc14f95b5468331cdcf1ffe6d2c4f4ce0ff04838b21cfa4d08e565d98398/libvcs-0.43.0-py3-none-any.whl", hash = "sha256:3bdc69fda0f8ec7482e7afc344b2e84eaabd9bfbf5b7f1ec44563c3322df0000", size = 102383, upload-time = "2026-06-20T19:08:07.779Z" },
 ]
 
 [[package]]
@@ -1770,7 +1770,7 @@ typings = [
 [package.metadata]
 requires-dist = [
     { name = "colorama", specifier = ">=0.3.9" },
-    { name = "libvcs", specifier = ">=0.42.0,<0.43.0" },
+    { name = "libvcs", specifier = ">=0.43.0,<0.44.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Bump libvcs from 0.42.0 to 0.43.0 (floor: `libvcs>=0.43.0,<0.44.0`).
- No vcspull source or test changes — no public libvcs API changed.

libvcs 0.43.0 restores pytest 9.1 compatibility for its auto-loaded
pytest plugin. Before 0.43.0, the plugin aborted the entire test
session on pytest 9.1+ for any project with libvcs installed. vcspull
runs pytest 9.1.0, so this unblocks the test suite.

See libvcs CHANGES: https://libvcs.git-pull.com/history.html#libvcs-0-43-0-2026-06-20

## Test plan

- [x] `uv run pytest` passes (1087 passed)
- [x] `uv run mypy` passes
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format .` clean