### PR TITLE
Explain branch/revision sync failures

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,16 @@ $ uvx --from 'vcspull' --prerelease allow vcspull
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+#### Clearer branch and revision sync failures (#557)
+
+When {ref}`cli-sync` cannot check out a configured branch, tag, or revision, the
+error output now names the requested `options.rev`, suggests pinning an existing
+branch or checking out a branch locally, and shows the remote branches Git
+reported. This turns a low-level checkout failure into guidance for repairing
+the repository configuration.
+
 ### Documentation
 
 - Command examples are re-captured from real runs; the sync and status

--- a/src/vcspull/cli/sync.py
+++ b/src/vcspull/cli/sync.py
@@ -1184,6 +1184,137 @@ def _emit_rerun_recipe(
         )
 
 
+_BRANCH_ERROR_SIGNATURES = (
+    "invalid upstream",
+    "no upstream",
+    "ambiguous argument",
+    "did not match any file",
+    "couldn't find remote ref",
+    "unknown revision",
+)
+
+
+def _looks_like_branch_error(err_msg: str, *, has_rev: bool) -> bool:
+    """Return True when a sync failure looks branch/revision-related.
+
+    A failed ``git checkout`` is only treated as a branch problem when the
+    repository pins a ``rev`` -- otherwise it may be an unrelated checkout
+    failure we should not second-guess.
+
+    Parameters
+    ----------
+    err_msg : str
+        The failure message surfaced by the sync.
+    has_rev : bool
+        Whether the repository configures an ``options.rev``.
+
+    Returns
+    -------
+    bool
+        True if the failure resembles a missing branch or revision.
+    """
+    lowered = err_msg.lower()
+    if has_rev and "git checkout" in lowered:
+        return True
+    return any(signature in lowered for signature in _BRANCH_ERROR_SIGNATURES)
+
+
+def _list_remote_branches(repo_path: pathlib.Path) -> list[str]:
+    """Return a repository's remote-tracking branch names (best-effort).
+
+    Parameters
+    ----------
+    repo_path : pathlib.Path
+        Local path to the repository.
+
+    Returns
+    -------
+    list of str
+        Remote-tracking branch names (e.g. ``origin/main``), empty on failure.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_path),
+                "for-each-ref",
+                "--format=%(refname:short)",
+                "refs/remotes",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    branches = []
+    for line in result.stdout.splitlines():
+        # A remote-tracking branch is always remote-qualified (``origin/main``);
+        # the bare remote name comes from the ``refs/remotes/<remote>/HEAD``
+        # symref and is not a branch.
+        name = line.strip()
+        if name and "/" in name and not name.endswith("/HEAD"):
+            branches.append(name)
+    return branches
+
+
+def _emit_branch_error_guidance(
+    formatter: OutputFormatter,
+    colors: Colors,
+    *,
+    repo: ConfigDict,
+    err_msg: str,
+) -> None:
+    """Emit actionable guidance when a sync fails on a branch/revision error.
+
+    Reacts to an actual failure rather than pre-checking, so healthy
+    repositories never see a spurious warning.
+
+    Parameters
+    ----------
+    formatter : OutputFormatter
+        Sink for human-facing text.
+    colors : Colors
+        Palette used to style the guidance.
+    repo : ConfigDict
+        The repository whose sync failed.
+    err_msg : str
+        The failure message surfaced by the sync.
+    """
+    rev = repo.get("rev")
+    if not _looks_like_branch_error(err_msg, has_rev=bool(rev)):
+        return
+
+    repo_path = pathlib.Path(str(repo.get("path", "")))
+    display_path = str(PrivatePath(repo_path))
+
+    formatter.emit_text("")
+    if rev:
+        formatter.emit_text(
+            f"{colors.info('→')} Revision {colors.warning(str(rev))} could not be "
+            f"checked out; it may not exist on the remote.",
+        )
+    else:
+        formatter.emit_text(
+            f"{colors.info('→')} This branch has no matching remote branch.",
+        )
+    formatter.emit_text(
+        f"    Pin an existing branch with {colors.muted('options.rev')}, or run "
+        f"{colors.muted(f'git -C {shlex.quote(display_path)} checkout <branch>')}",
+    )
+
+    branches = _list_remote_branches(repo_path)
+    if branches:
+        formatter.emit_text(
+            f"{colors.info('→')} Available remote branches: "
+            f"{colors.muted(', '.join(branches[:10]))}",
+        )
+
+
 def sync(
     repo_patterns: list[str],
     config: pathlib.Path | None,
@@ -1737,6 +1868,13 @@ def _run_sync_loop(
                 traceback.print_exception(type(err), err, err.__traceback__)
             if not wrote_final:
                 formatter.emit_text(permanent)
+            if is_human:
+                _emit_branch_error_guidance(
+                    formatter,
+                    colors,
+                    repo=repo,
+                    err_msg=err_msg,
+                )
             if exit_on_error:
                 _emit_summary(formatter, colors, summary)
                 formatter.finalize()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -811,7 +811,12 @@ SYNC_REV_BRANCH_MISMATCH_FIXTURES: list[SyncRevBranchMismatchFixture] = [
     SyncRevBranchMismatchFixture(
         test_id="rev-master-on-main-only-remote",
         sync_args=["my_repo"],
-        expected_in_out="Failed syncing",
+        expected_in_out=[
+            "Failed syncing",
+            "could not be checked out",
+            "options.rev",
+            "Available remote branches: origin/main",
+        ],
         expected_not_in_out="Synced my_repo",
     ),
     SyncRevBranchMismatchFixture(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -22,7 +22,7 @@ from libvcs.sync.hg import HgSync
 from libvcs.sync.svn import SvnSync
 
 from vcspull._internal.config_reader import ConfigReader
-from vcspull.cli.sync import sync, update_repo
+from vcspull.cli.sync import _looks_like_branch_error, sync, update_repo
 from vcspull.config import (
     detect_git_depth,
     detect_git_shallow,
@@ -666,3 +666,61 @@ def test_load_configs_warns_on_legacy_options(
     assert "vcspull migrate" in record.getMessage()
     assert record.vcspull_config_path == str(config_file)
     assert record.vcspull_legacy_count == affected_count
+
+
+class BranchErrorDetectionFixture(t.NamedTuple):
+    """pytest fixture for _looks_like_branch_error classification."""
+
+    test_id: str
+    err_msg: str
+    has_rev: bool
+    expected: bool
+
+
+BRANCH_ERROR_DETECTION_FIXTURES: list[BranchErrorDetectionFixture] = [
+    BranchErrorDetectionFixture(
+        test_id="rev-checkout-failure",
+        err_msg="Command failed with code 1: git checkout master",
+        has_rev=True,
+        expected=True,
+    ),
+    BranchErrorDetectionFixture(
+        test_id="checkout-failure-without-rev",
+        err_msg="Command failed with code 1: git checkout master",
+        has_rev=False,
+        expected=False,
+    ),
+    BranchErrorDetectionFixture(
+        test_id="invalid-upstream",
+        err_msg="fatal: invalid upstream 'origin/feature'",
+        has_rev=False,
+        expected=True,
+    ),
+    BranchErrorDetectionFixture(
+        test_id="ambiguous-argument",
+        err_msg="fatal: ambiguous argument 'notes': unknown revision",
+        has_rev=False,
+        expected=True,
+    ),
+    BranchErrorDetectionFixture(
+        test_id="unrelated-network-error",
+        err_msg="fatal: unable to access; Could not resolve host: example.com",
+        has_rev=True,
+        expected=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(BranchErrorDetectionFixture._fields),
+    BRANCH_ERROR_DETECTION_FIXTURES,
+    ids=[test.test_id for test in BRANCH_ERROR_DETECTION_FIXTURES],
+)
+def test_looks_like_branch_error(
+    test_id: str,
+    err_msg: str,
+    has_rev: bool,
+    expected: bool,
+) -> None:
+    """Test _looks_like_branch_error classifies sync failures correctly."""
+    assert _looks_like_branch_error(err_msg, has_rev=has_rev) is expected


### PR DESCRIPTION
## Summary

- detect sync failures caused by a configured branch or revision that cannot be checked out
- show recovery guidance naming the offending revision and available remote branches
- add the PR changelog item in CHANGES

## Tests

- `git diff --check`
- Earlier branch gate before the final CHANGES-only amend: `uv run ruff format .`, `uv run py.test` (1092 passed), `uv run ruff check . --fix --show-fixes`, `uv run mypy`, `uv run py.test` (1092 passed), `just build-docs` (succeeded with 3 existing duplicate-label warnings)